### PR TITLE
[JENKINS-24399] A test to reproduce JENKINS-24399

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScriptTest.java
@@ -37,6 +37,7 @@ import hudson.security.Permission;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
 import java.io.File;
+import java.io.FileFilter;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
@@ -497,6 +498,25 @@ public class SecureGroovyScriptTest {
             FreeStyleBuild b = p.scheduleBuild2(0).get();
             r.assertBuildStatusSuccess(b);
             assertEquals(testingDisplayName, b.getDisplayName());
+        }
+        
+        // add a new file in a subdirectory of the tmpDir.
+        {
+            File f = tmpFolderRule.newFile();
+            File targetDir = tmpDir.listFiles(new FileFilter(){
+                public boolean accept(File pathname) {
+                    return pathname.isDirectory();
+                }
+                
+            })[0];
+            FileUtils.copyFileToDirectory(f, targetDir);
+        }
+        
+        // Should fail as the class directory is updated.
+        {
+            FreeStyleBuild b = p.scheduleBuild2(0).get();
+            r.assertBuildStatus(Result.FAILURE, b);
+            assertNotEquals(testingDisplayName, b.getDisplayName());
         }
     }
     


### PR DESCRIPTION
This is a demonstration for [JENKINS-24399] (https://issues.jenkins-ci.org/browse/JENKINS-24399) Modifying files in class directories can bypass approval in script-security (or class directories are accepted as classpaths).
Do not merge.

script-security 1.5 allows to use a class directory as an additional classpath.
This test shows that users can use class directories whose contents are modified without administrators' approval.