### PR TITLE
[JENKINS-25119] a test for additional methods in the Groovy environment

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -388,6 +388,16 @@ public class SandboxInterceptorTest {
         assertEvaluate(new GenericWhitelist(), Collections.singletonMap("part0", "one\ntwo"), "def list = [['one', 'two']]; def map = [:]; for (int i = 0; i < list.size(); i++) {map[\"part${i}\"] = list.get(i).join(\"\\n\")}; map");
     }
 
+    @Issue("JENKINS-25119")
+    @Test public void groovyAdditionalMethod() throws Exception {
+        try {
+            assertEvaluate(new ProxyWhitelist(), "should fail", "'123'.toInteger();");
+        } catch (RejectedAccessException x) {
+            assertNotNull(x.toString(), x.getSignature());
+        }
+        assertEvaluate(new StaticWhitelist("staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toInteger java.lang.String"), new Integer(123), "'123'.toInteger();");
+    }
+
     private static void assertEvaluate(Whitelist whitelist, final Object expected, final String script) {
         final GroovyShell shell = new GroovyShell(GroovySandbox.createSecureCompilerConfiguration());
         Object actual = GroovySandbox.run(shell.parse(script), whitelist);


### PR DESCRIPTION
Sorry for my late work.
This is a test for [JENKINS-25119](https://issues.jenkins-ci.org/browse/JENKINS-25119) fixed in 52d83beb4227416c1fa14e20099ff75400fb6a63, script-security-1.11.

This test fails in script-security <= 1.10 as following:
```
-------------------------------------------------------------------------------
Test set: org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptorTest
-------------------------------------------------------------------------------
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.266 sec <<< FAILURE!
groovyExtendedMethod(org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptorTest)  Time elapsed: 1.11 sec  <<< FAILURE!
java.lang.AssertionError: org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: unclassified method java.lang.String toInteger
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.junit.Assert.assertNotNull(Assert.java:621)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptorTest.groovyExtendedMethod(SandboxInterceptorTest.java:360)
```