### PR TITLE
Pin the jffi version as 1.2.7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,5 +59,19 @@
             <version>1.1</version>
             <scope>test</scope>
         </dependency>
+        <!-- TODO as of 1.532.x+ the inherited version is not a range dep and so the following two overrides can be removed: -->
+        <dependency>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jffi</artifactId>
+            <version>1.2.7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jffi</artifactId>
+            <version>1.2.7</version>
+            <classifier>native</classifier>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Otherwise Maven builds started failing recently:

    Could not resolve dependencies for project org.jenkins-ci.plugins:script-security:hpi:1.14-SNAPSHOT: Could not find artifact com.github.jnr:jffi:jar:native:1.2.8-20150130.202743-5 in …

Older versions of core bundle a version of JNR that includes a range dependency on `jffi`, which causes failures on projects using a transitive dependency when new snapshot versions are deployed inside the range. This patch just pins the version to that which 1.509.4 actually bundles.

Simply upgrading the core dep would be easier, but that would also prevent updates from being used from `groovy-postbuild`, at least until _that_ plugin gets a newer core dep. Similarly for other plugins which might be using `script-security` in the near future.

@reviewbybees esp. @tfennelly