### PR TITLE
[JENKINS-28154] Reproduce in unittest

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -40,7 +40,10 @@ staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter compareEqual java
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter compareNotEqual java.lang.Object java.lang.Object
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter findRegex java.lang.Object java.lang.Object
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter matchRegex java.lang.Object java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Object groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods disjoint java.util.Collection java.util.Collection
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join java.util.Collection java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Collection java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods or java.lang.Boolean java.lang.Boolean
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods xor java.lang.Boolean java.lang.Boolean

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -24,6 +24,9 @@
 
 package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import groovy.json.JsonBuilder;
 import groovy.json.JsonDelegate;
 import groovy.lang.GString;
@@ -35,6 +38,7 @@ import groovy.lang.Script;
 import groovy.text.SimpleTemplateEngine;
 import groovy.text.Template;
 import hudson.Functions;
+import hudson.util.IOUtils;
 
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -56,7 +60,6 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.GenericWhitelist;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
-import static org.junit.Assert.*;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -216,7 +219,7 @@ public class SandboxInterceptorTest {
             this._prop2 = prop2;
         }
     }
-    
+
     @Test public void dynamicProperties() throws Exception {
         String dynamic = Dynamic.class.getName();
         String ctor = "new " + dynamic;
@@ -367,7 +370,7 @@ public class SandboxInterceptorTest {
             }
         }, new ProxyWhitelist(new StaticWhitelist("method java.lang.String toLowerCase"), new GenericWhitelist())));
     }
-    
+
     @Test public void selfProperties() throws Exception {
         assertEvaluate(new ProxyWhitelist(), true, "BOOL=true; BOOL");
     }
@@ -435,6 +438,11 @@ public class SandboxInterceptorTest {
 
     @Test public void splitAndJoin() throws Exception {
         assertEvaluate(new GenericWhitelist(), Collections.singletonMap("part0", "one\ntwo"), "def list = [['one', 'two']]; def map = [:]; for (int i = 0; i < list.size(); i++) {map[\"part${i}\"] = list.get(i).join(\"\\n\")}; map");
+    }
+
+    @Test public void keywordsAndOperators() throws Exception {
+        String script = IOUtils.toString(this.getClass().getResourceAsStream("SandboxInterceptorTest/all.groovy"));
+        assertEvaluate(new GenericWhitelist(), null, script);
     }
 
     private static void assertEvaluate(Whitelist whitelist, final Object expected, final String script) {

--- a/src/test/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest/all.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest/all.groovy
@@ -1,0 +1,122 @@
+// A script that should exercise all keywords and operators.
+// TODO:
+// ===
+// !==
+// ||=
+// &&=
+// \
+// \=
+// native
+// KEYWORD_DEFMACRO
+// mixin
+// KEYWORD_IMPORT
+// KEYWORD_DO
+
+package test
+
+def fun() {
+  return [];
+}
+
+arr = fun();
+assert arr.collect { it -> it } == [];
+arr << 0;
+assert arr == [0];
+
+assert true in [true, false];
+(1..3).each {};
+[1..3]*.toString();
+assert 42 as String == "42"
+assert 0 == [1:0][1];
+
+assert "asdf" =~ /sd/
+assert "asdf" ==~ /asdf/
+assert ~/asdf/ instanceof java.util.regex.Pattern
+
+assert 1 < 2 && 1 <= 2
+assert 2 > 1 && 2 >= 1
+assert 1 <=> 1 == 0
+assert false || !false
+
+assert (6 / 3 + 4) * (2 ** 3 - (3 % 2)) == 42
+
+int a = 1
+a += 1
+a *= 2
+a **= 2
+a /= 2
+a %= 5
+assert a == 3
+
+l = 1;
+r = 3;
+assert ++l-- == --r++;
+assert +0 == -0
+
+assert (2 << 1) + (8 >> 1) == (16 >>> 1);
+
+def b = 8;
+b >>= 1;
+b >>>= 1;
+b <<= 2;
+assert b == 8;
+
+assert !(false ? true : false)
+assert false?:true;
+assert null?.hashCode() == null
+
+assert (1 | 2) == (1 & 3) + (1 ^ 3);
+
+int bin = 15;
+bin ^= 5;
+bin |= 3;
+bin &= 6;
+assert bin == 2;
+
+interface I {}
+
+abstract strictfp class A implements I {
+    final transient int v = 42;
+    volatile double a;
+    long l;
+    float f;
+    char ch;
+    {}
+    static {}
+    protected static synchronized byte s() throws IOException {}
+    public abstract void f();
+    private short p() {};
+    def d(String... s) { return 0 };
+}
+
+class E extends A {
+    public void f() {
+        def superP = super.&p;
+        superP();
+        def arr = ["Lorem", "ipsum"];
+        this.d(*arr);
+    }
+    private int field;
+}
+
+assert new E() {} instanceof I;
+new E().@field = 42;
+
+if (false) {
+    assert false;
+} else {
+    assert true;
+}
+label: for (i in [1, 2]) { continue label; }
+
+switch (false) {
+    case null: break;
+    case true: break;
+    default: break;
+}
+
+try {
+    throw new Exception();
+} catch (Exception _) {
+} finally {
+}


### PR DESCRIPTION
[JENKINS-28154](https://issues.jenkins-ci.org/browse/JENKINS-28154)

I tried to exercise as much operators/keywords as possible, though only `in` (membership operator, not foreach separator) seems to cause this problem. I also whitelisted  some methods.