### PR TITLE
Fixed incorrect sandbox check when invoking GDM method on a class that defines invokeMethod.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptor.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptor.java
@@ -54,20 +54,20 @@ final class SandboxInterceptor extends GroovyInterceptor {
                 return super.onMethodCall(invoker, receiver, method, args);
             }
 
-            // if no matching method, look for catchAll "invokeMethod"
-            try {
-                receiver.getClass().getMethod("invokeMethod", String.class, Object.class);
-                return onMethodCall(invoker,receiver,"invokeMethod",method,args);
-            } catch (NoSuchMethodException e) {
-                // fall through
-            }
-
             // look for GDK methods
             Object[] selfArgs = new Object[args.length + 1];
             selfArgs[0] = receiver;
             System.arraycopy(args, 0, selfArgs, 1, args.length);
             if (GroovyCallSiteSelector.staticMethod(DefaultGroovyMethods.class, method, selfArgs) != null) {
                 return onStaticCall(invoker, DefaultGroovyMethods.class, method, selfArgs);
+            }
+
+            // if no matching method, look for catchAll "invokeMethod"
+            try {
+                receiver.getClass().getMethod("invokeMethod", String.class, Object.class);
+                return onMethodCall(invoker,receiver,"invokeMethod",method,args);
+            } catch (NoSuchMethodException e) {
+                // fall through
             }
 
             throw new RejectedAccessException("unclassified method " + EnumeratingWhitelist.getName(receiver.getClass()) + " " + method + printArgumentTypes(args));

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -44,3 +44,4 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods disjoint java.util
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join java.util.Collection java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods or java.lang.Boolean java.lang.Boolean
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods xor java.lang.Boolean java.lang.Boolean
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods asBoolean java.lang.Object

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -26,16 +26,19 @@ package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
 
 import groovy.json.JsonBuilder;
 import groovy.json.JsonDelegate;
+import groovy.lang.Closure;
 import groovy.lang.GString;
 import groovy.lang.GroovyObject;
 import groovy.lang.GroovyObjectSupport;
 import groovy.lang.GroovyShell;
+import groovy.lang.MetaMethod;
 import groovy.lang.MissingPropertyException;
 import groovy.lang.Script;
 import groovy.text.SimpleTemplateEngine;
 import groovy.text.Template;
 import hudson.Functions;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.Arrays;
@@ -47,6 +50,7 @@ import java.util.concurrent.Callable;
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.runtime.GStringImpl;
+import org.codehaus.groovy.runtime.InvokerHelper;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.AbstractWhitelist;
@@ -435,6 +439,39 @@ public class SandboxInterceptorTest {
 
     @Test public void splitAndJoin() throws Exception {
         assertEvaluate(new GenericWhitelist(), Collections.singletonMap("part0", "one\ntwo"), "def list = [['one', 'two']]; def map = [:]; for (int i = 0; i < list.size(); i++) {map[\"part${i}\"] = list.get(i).join(\"\\n\")}; map");
+    }
+
+    public static class ClassWithInvokeMethod extends GroovyObjectSupport {
+        @Override
+        public Object invokeMethod(String name, Object args) {
+            throw new IllegalStateException();
+        }
+    }
+
+    @Test public void invokeMethod_vs_DefaultGroovyMethods() throws Exception {
+        // Closure defines the invokeMethod method, and asBoolean is defined on DefaultGroovyMethods.
+        // the method dispatching in this case is that c.asBoolean() resolves to DefaultGroovyMethods.asBoolean()
+        // and not invokeMethod("asBoolean")
+
+        // calling asBoolean shouldn't go through invokeMethod
+        MetaMethod m1 = InvokerHelper.getMetaClass(ClassWithInvokeMethod.class).pickMethod("asBoolean",new Class[0]);
+        assert m1!=null;
+        assert (Boolean)m1.invoke(new ClassWithInvokeMethod(),new Object[0]);
+
+        // as such, it should be allowed so long as asBoolean is whitelisted
+        assertEvaluate(
+                new ProxyWhitelist(
+                        new GenericWhitelist(),
+                        new AbstractWhitelist() {
+                            @Override
+                            public boolean permitsConstructor(Constructor<?> constructor, Object[] args) {
+                                return constructor.getDeclaringClass()==ClassWithInvokeMethod.class;
+                            }
+                        }
+                ),
+                true,
+                "def c = new org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptorTest.ClassWithInvokeMethod(); c.asBoolean()"
+        );
     }
 
     private static void assertEvaluate(Whitelist whitelist, final Object expected, final String script) {


### PR DESCRIPTION
The groovy runtime would resolve a call to a GroovyDefaultMethods method in this case, but the script-security check incorrectly concludes that the call would resolve to the invokeMethod method.