### PR TITLE
[JENKINS-29541] GString receiver handling

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
@@ -89,14 +89,13 @@ class GroovyCallSiteSelector {
      */
     public static @CheckForNull Method method(@Nonnull Object receiver, @Nonnull String method, @Nonnull Object[] args) {
         for (Class<?> c : types(receiver)) {
-            Method candidate = null;
-            for (Method m : c.getDeclaredMethods()) {
-                if (m.getName().equals(method) && matches(m.getParameterTypes(), args)) {
-                    if (candidate == null || isMoreSpecific(m, candidate)) {
-                        candidate = m;
-                    }
-                }
+            Method candidate = findMatchingMethod(c, method, args);
+            if (candidate != null) {
+                return candidate;
             }
+        }
+        if (receiver instanceof GString) { // cf. GString.invokeMethod
+            Method candidate = findMatchingMethod(String.class, method, args);
             if (candidate != null) {
                 return candidate;
             }
@@ -115,6 +114,10 @@ class GroovyCallSiteSelector {
 
     public static @CheckForNull Method staticMethod(@Nonnull Class<?> receiver, @Nonnull String method, @Nonnull Object[] args) {
         // TODO should we check for inherited static calls?
+        return findMatchingMethod(receiver, method, args);
+    }
+
+    private static Method findMatchingMethod(Class<?> receiver, String method, Object[] args) {
         Method candidate = null;
         for (Method m : receiver.getDeclaredMethods()) {
             if (m.getName().equals(method) && matches(m.getParameterTypes(), args)) {

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -20,6 +20,7 @@ method java.lang.String trim
 method java.lang.String matches java.lang.String
 method java.lang.String split java.lang.String
 method java.lang.String startsWith java.lang.String
+method java.lang.String substring int int
 method java.lang.String replace java.lang.CharSequence java.lang.CharSequence
 method java.util.Collection contains java.lang.Object
 method java.util.concurrent.Callable call

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
@@ -25,11 +25,14 @@
 package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
 
 import com.google.common.io.NullOutputStream;
+import groovy.lang.GString;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
+import org.codehaus.groovy.runtime.GStringImpl;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.EnumeratingWhitelistTest;
 import static org.junit.Assert.*;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 public class GroovyCallSiteSelectorTest {
 
@@ -45,6 +48,14 @@ public class GroovyCallSiteSelectorTest {
         assertEquals(PrintWriter.class.getMethod("print", Object.class), GroovyCallSiteSelector.method(receiver, "print", new Object[] {new Object()}));
         assertEquals(PrintWriter.class.getMethod("print", String.class), GroovyCallSiteSelector.method(receiver, "print", new Object[] {"message"}));
         assertEquals(PrintWriter.class.getMethod("print", int.class), GroovyCallSiteSelector.method(receiver, "print", new Object[] {42}));
+    }
+
+    @Issue("JENKINS-29541")
+    @Test public void methodsOnGString() throws Exception {
+        GStringImpl gString = new GStringImpl(new Object[0], new String[] {"x"});
+        assertEquals(String.class.getMethod("substring", int.class), GroovyCallSiteSelector.method(gString, "substring", new Object[] {99}));
+        assertEquals(GString.class.getMethod("getValues"), GroovyCallSiteSelector.method(gString, "getValues", new Object[0]));
+        assertEquals(GString.class.getMethod("getStrings"), GroovyCallSiteSelector.method(gString, "getStrings", new Object[0]));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -88,6 +88,13 @@ public class SandboxInterceptorTest {
         assertEvaluate(new StaticWhitelist("new " + clazz, "method " + clazz + " specialize java.lang.Object", "method " + clazz + " quote java.lang.Object"), expected, script);
     }
 
+    @Ignore("TODO second line fails with: Scripts not permitted to use method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object (org.codehaus.groovy.runtime.GStringImpl substring java.lang.Integer java.lang.Integer)")
+    @Issue("JENKINS-29541")
+    @Test public void substringGString() throws Exception {
+        assertEvaluate(new GenericWhitelist(), "hell", "'hello world'.substring(0, 4)");
+        assertEvaluate(new GenericWhitelist(), "hell", "def place = 'world'; \"hello ${place}\".substring(0, 4)");
+    }
+
     /**
      * Tests the proper interception of builder-like method.
      */

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -88,7 +88,6 @@ public class SandboxInterceptorTest {
         assertEvaluate(new StaticWhitelist("new " + clazz, "method " + clazz + " specialize java.lang.Object", "method " + clazz + " quote java.lang.Object"), expected, script);
     }
 
-    @Ignore("TODO second line fails with: Scripts not permitted to use method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object (org.codehaus.groovy.runtime.GStringImpl substring java.lang.Integer java.lang.Integer)")
     @Issue("JENKINS-29541")
     @Test public void substringGString() throws Exception {
         assertEvaluate(new GenericWhitelist(), "hell", "'hello world'.substring(0, 4)");


### PR DESCRIPTION
[JENKINS-29541](https://issues.jenkins-ci.org/browse/JENKINS-29541)

Adding a whitelist entry for `String.substring` is trivial and in fact an administrator could do so for themselves. The bigger problem was with `GString`, whose `invokeMethod` is a little hack to delegate unknown methods to `String`; this needs special treatment. (Ideally the Groovy sandbox library would handle this sort of painful detail, but it does not.)

@reviewbybees