### PR TITLE
[JENKINS-30432] Warn about dangerous signatures

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/RejectedAccessException.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/RejectedAccessException.java
@@ -79,6 +79,7 @@ public final class RejectedAccessException extends SecurityException {
 
     /**
      * True if {@link #getSignature} is non-null but it would be a bad idea for an administrator to approve it.
+     * @since TODO 1.16?
      */
     public boolean isDangerous() {
         return dangerous;
@@ -86,6 +87,8 @@ public final class RejectedAccessException extends SecurityException {
 
     /**
      * You may set this flag if you think it would be a security risk for this signature to be approved.
+     * @throws IllegalArgumentException in case you tried to set this to true when using the nonspecific {@link #RejectedAccessException(String)} constructor
+     * @since TODO 1.16?
      */
     public void setDangerous(boolean dangerous) {
         if (signature == null && dangerous) {

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/RejectedAccessException.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/RejectedAccessException.java
@@ -35,6 +35,7 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist;
 public final class RejectedAccessException extends SecurityException {
 
     private final String signature;
+    private boolean dangerous;
 
     /**
      * Rejects access to a well-described script element.
@@ -74,6 +75,23 @@ public final class RejectedAccessException extends SecurityException {
      */
     public @CheckForNull String getSignature() {
         return signature;
+    }
+
+    /**
+     * True if {@link #getSignature} is non-null but it would be a bad idea for an administrator to approve it.
+     */
+    public boolean isDangerous() {
+        return dangerous;
+    }
+
+    /**
+     * You may set this flag if you think it would be a security risk for this signature to be approved.
+     */
+    public void setDangerous(boolean dangerous) {
+        if (signature == null && dangerous) {
+            throw new IllegalArgumentException("you cannot mark this dangerous without specifying a signature");
+        }
+        this.dangerous = dangerous;
     }
 
 }

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/blacklist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/blacklist
@@ -1,0 +1,11 @@
+# Raw file operations could be used to compromise the Jenkins master.
+new java.io.File java.lang.String
+new java.io.File java.lang.String java.lang.String
+new java.io.File java.net.URI
+
+# Reflective access to Groovy is too open-ended. Approve only specific GroovyObject subclass methods.
+method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object
+method groovy.lang.GroovyObject getProperty java.lang.String
+method groovy.lang.GroovyObject setProperty java.lang.String java.lang.Object
+method groovy.lang.GroovyObject getMetaClass
+method groovy.lang.GroovyObject setMetaClass groovy.lang.MetaClass

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
@@ -215,6 +215,9 @@ THE SOFTWARE.
                                 <button onclick="denySignature('${s.signature}', '${s.hash}')">Deny</button> signature
                                 <st:include it="${s.context}" page="index.jelly"/>:
                                 <code>${s.signature}</code>
+                                <j:if test="${s.dangerous}">
+                                    <st:nbsp/><strong><font color="red">Approving this signature may introduce a security vulnerability! You are advised to deny it.</font></strong>
+                                </j:if>
                             </p>
                         </div>
                     </j:forEach>

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists;
+
+import groovy.lang.GroovyObject;
+import java.io.File;
+import java.util.Collection;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class StaticWhitelistTest {
+    
+    @Test public void dangerous() throws Exception {
+        assertFalse(StaticWhitelist.rejectMethod(Collection.class.getMethod("clear")).isDangerous());
+        assertTrue(StaticWhitelist.rejectNew(File.class.getConstructor(String.class)).isDangerous());
+        assertTrue(StaticWhitelist.rejectMethod(GroovyObject.class.getMethod("invokeMethod", String.class, Object.class)).isDangerous());
+    }
+
+}


### PR DESCRIPTION
In [JENKINS-30432](https://issues.jenkins-ci.org/browse/JENKINS-30432) for example, the user naïvely approved a signature that should never be approved. I have also seen @rsandell accidentally approve usage of `File` methods, which is even more dangerous. Introducing a blacklist of signatures known to be exploitable, or which would have no legitimate use, and sternly warning the administrator not to accept them.

@reviewbybees