### PR TITLE
Whitelist JsonSlurper and JsonOutput

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -1,4 +1,19 @@
 # Groovy:
+staticMethod groovy.json.JsonOutput prettyPrint java.lang.String
+staticMethod groovy.json.JsonOutput toJson groovy.lang.Closure
+staticMethod groovy.json.JsonOutput toJson java.lang.Boolean
+staticMethod groovy.json.JsonOutput toJson java.lang.Character
+staticMethod groovy.json.JsonOutput toJson java.lang.Number
+staticMethod groovy.json.JsonOutput toJson java.lang.Object
+staticMethod groovy.json.JsonOutput toJson java.lang.String
+staticMethod groovy.json.JsonOutput toJson java.net.URL
+staticMethod groovy.json.JsonOutput toJson java.util.Calendar
+staticMethod groovy.json.JsonOutput toJson java.util.Date
+staticMethod groovy.json.JsonOutput toJson java.util.Map
+staticMethod groovy.json.JsonOutput toJson java.util.UUID
+new groovy.json.JsonSlurper
+method groovy.json.JsonSlurper parseText java.lang.String
+
 staticField groovy.lang.Closure DELEGATE_FIRST
 staticField groovy.lang.Closure DELEGATE_ONLY
 staticField groovy.lang.Closure OWNER_FIRST


### PR DESCRIPTION
Whitelist JsonSlurper and JsonOutput, the JSON parser and formatter recommended by http://www.groovy-lang.org/json.html