### PR TITLE
Updated baseline to 1.580.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.509.4</version>
+        <version>1.580.1</version>
     </parent>
     <artifactId>script-security</artifactId>
     <version>1.17-SNAPSHOT</version>
@@ -56,26 +56,6 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
             <version>3.0.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency> <!-- TODO default as of 1.568+ -->
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>test-annotations</artifactId>
-            <version>1.1</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- TODO as of 1.532.x+ the inherited version is not a range dep and so the following two overrides can be removed: -->
-        <dependency>
-            <groupId>com.github.jnr</groupId>
-            <artifactId>jffi</artifactId>
-            <version>1.2.7</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.jnr</groupId>
-            <artifactId>jffi</artifactId>
-            <version>1.2.7</version>
-            <classifier>native</classifier>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/RejectedAccessException.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/RejectedAccessException.java
@@ -79,7 +79,7 @@ public final class RejectedAccessException extends SecurityException {
 
     /**
      * True if {@link #getSignature} is non-null but it would be a bad idea for an administrator to approve it.
-     * @since TODO 1.16?
+     * @since 1.16
      */
     public boolean isDangerous() {
         return dangerous;
@@ -88,7 +88,7 @@ public final class RejectedAccessException extends SecurityException {
     /**
      * You may set this flag if you think it would be a security risk for this signature to be approved.
      * @throws IllegalArgumentException in case you tried to set this to true when using the nonspecific {@link #RejectedAccessException(String)} constructor
-     * @since TODO 1.16?
+     * @since 1.16
      */
     public void setDangerous(boolean dangerous) {
         if (signature == null && dangerous) {

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import static java.util.Arrays.asList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -82,17 +83,17 @@ public final class StaticWhitelist extends EnumeratingWhitelist {
             if (toks.length < 3) {
                 throw new IOException(line);
             }
-            return new MethodSignature(toks[1], toks[2], slice(toks, 3));
+            return new MethodSignature(toks[1], toks[2], Arrays.copyOfRange(toks, 3, toks.length));
         } else if (toks[0].equals("new")) {
             if (toks.length < 2) {
                 throw new IOException(line);
             }
-            return new NewSignature(toks[1], slice(toks, 2));
+            return new NewSignature(toks[1], Arrays.copyOfRange(toks, 2, toks.length));
         } else if (toks[0].equals("staticMethod")) {
             if (toks.length < 3) {
                 throw new IOException(line);
             }
-            return new StaticMethodSignature(toks[1], toks[2], slice(toks, 3));
+            return new StaticMethodSignature(toks[1], toks[2], Arrays.copyOfRange(toks, 3, toks.length));
         } else if (toks[0].equals("field")) {
             if (toks.length != 3) {
                 throw new IOException(line);
@@ -121,13 +122,6 @@ public final class StaticWhitelist extends EnumeratingWhitelist {
         } else {
             newSignatures.add((NewSignature) s);
         }
-    }
-
-    private static String[] slice(String[] toks, int from) {
-        // TODO Java 6: return Arrays.copyOfRange(toks, from, toks.length);
-        String[] r = new String[toks.length - from];
-        System.arraycopy(toks, from, r, 0, toks.length - from);
-        return r;
     }
 
     public static StaticWhitelist from(URL definition) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/languages/GroovyLanguage.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/languages/GroovyLanguage.java
@@ -46,7 +46,7 @@ import jenkins.model.Jenkins;
     }
 
     @Override public String getCodeMirrorMode() {
-        return "clike"; // TODO 1.560: "groovy"
+        return "groovy";
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScriptTest.java
@@ -849,7 +849,7 @@ public class SecureGroovyScriptTest {
     /**
      * Get the form button having the specified text/caption.
      *
-     * TODO 1.627+ use standard version from HtmlFormUtil
+     * TODO 1.627+ or jenkins-test-harness 2.0+ use standard version from HtmlFormUtil
      *
      * @param htmlForm The form containing the button.
      * @param caption The button text/caption being searched for.


### PR DESCRIPTION
After https://github.com/jenkinsci/groovy-postbuild-plugin/pull/24 the oldest baseline used by any plugin depending on this one is 1.580.x (`parallel-test-executor`), followed by 1.596.x (`docker-workflow`); the rest are on 1.609.x.

(As a maintainer of both of those I am tempted to just bump them up too, but that can wait.)

@reviewbybees