### PR TITLE
Add Entry getKey/getValue for java.util.Map

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -80,6 +80,8 @@ method java.util.Collection size
 method java.util.List get int
 method java.util.Map get java.lang.Object
 method java.util.Map put java.lang.Object java.lang.Object
+method java.util.Map$Entry getKey
+method java.util.Map$Entry getValue
 method java.util.concurrent.Callable call
 method java.util.regex.Matcher replaceFirst java.lang.String
 


### PR DESCRIPTION
It's nice to be able to get values when iterating over map entries (otherwise all you can do is get known key values out). 

@reviewbybees 