### PR TITLE
MetaClass delegate handling

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/jenkins-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/jenkins-whitelist
@@ -2,6 +2,7 @@
 new hudson.EnvVars
 method hudson.model.AbstractBuild getEnvironments
 staticMethod hudson.model.Environment create hudson.EnvVars
+method hudson.model.Item getParent
 method hudson.model.ModelObject getDisplayName
 method hudson.model.Run getFullDisplayName
 method hudson.tools.ToolInstallation getHome

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -416,6 +416,7 @@ public class SandboxInterceptorTest {
         new GroovyShell().evaluate("String.metaClass.getAnswer = {-> return 42}"); // privileged operation
         assertEvaluate(new StaticWhitelist(), 42, "'existence'.getAnswer()");
         assertEvaluate(new StaticWhitelist(), 42, "'existence'.answer");
+        assertRejected(new StaticWhitelist("method groovy.lang.Closure call java.lang.Object"), "staticMethod java.lang.System exit int", "def c = System.&exit; c(1)");
     }
 
     @Issue("JENKINS-28277")

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -412,6 +412,12 @@ public class SandboxInterceptorTest {
         }
     }
 
+    @Test public void metaClassDelegate() throws Exception {
+        new GroovyShell().evaluate("String.metaClass.getAnswer = {-> return 42}"); // privileged operation
+        assertEvaluate(new StaticWhitelist(), 42, "'existence'.getAnswer()");
+        assertEvaluate(new StaticWhitelist(), 42, "'existence'.answer");
+    }
+
     @Issue("JENKINS-28277")
     @Test public void curry() throws Exception {
         assertEvaluate(new GenericWhitelist(), 'h', "def charAt = {idx, str -> str.charAt(idx)}; def firstChar = charAt.curry(0); firstChar 'hello'");


### PR DESCRIPTION
Found that a trick used to bind synthetic methods to existing classes was being rejected by the sandbox. Here it is assumed that the closure itself is implicitly whitelisted; `Whitelist` does not have any mechanism for listing non-Java “methods” like this.

@reviewbybees esp. @kohsuke