### PR TITLE
[JENKINS-24399] Don't allow class directories any more.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntry.java
@@ -65,15 +65,46 @@ public final class ClasspathEntry extends AbstractDescribableImpl<ClasspathEntry
         }
     }
 
-    static String urlToPath(URL url) {
+    /** Returns {@code null} if another protocol or unable to perform the conversion. */
+    private static File urlToFile(@Nonnull URL url) {
         if (url.getProtocol().equals("file")) {
             try {
-                return new File(url.toURI()).getAbsolutePath();
+                return new File(url.toURI());
             } catch (URISyntaxException x) {
                 // ?
             }
         }
-        return url.toString();
+        return null;
+    }
+
+    static String urlToPath(URL url) {
+        final File file = urlToFile(url);
+        return file != null ? file.getAbsolutePath() : url.toString();
+    }
+
+    /**
+     * Checks whether an URL would be considered a class directory by {@link java.net.URLClassLoader}.
+     * According to its <a href="http://docs.oracle.com/javase/6/docs/api/java/net/URLClassLoader.html"specification</a>
+     * an URL will be considered an class directory if it ends with /.
+     * In the case the URL uses a {@code file:} protocol a check is performed to see if it is a directory as an additional guard
+     * in case a different class loader is used by other {@link Language} implementation.
+     */
+    static boolean isClassDirectoryURL(@Nonnull URL url) {
+        final File file = urlToFile(url);
+        if (file != null && file.isDirectory()) {
+            return true;
+            // If the URL is a file but does not exist we fallback to default behaviour
+            // as non existence will be dealt with when trying to use it.
+        }
+        return url.toExternalForm().endsWith("/");
+    }
+
+    /**
+     * Checks whether the entry would be considered a class directory.
+     * @see #isClassDirectoryURL(URL)
+     */
+    public boolean isClassDirectory() {
+        return isClassDirectoryURL(url);
     }
     
     public @Nonnull String getPath() {
@@ -83,7 +114,7 @@ public final class ClasspathEntry extends AbstractDescribableImpl<ClasspathEntry
     public @Nonnull URL getURL() {
         return url;
     }
-    
+
     private @CheckForNull URI getURI() {
         try {
             return url.toURI();

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntry.java
@@ -96,7 +96,8 @@ public final class ClasspathEntry extends AbstractDescribableImpl<ClasspathEntry
             // If the URL is a file but does not exist we fallback to default behaviour
             // as non existence will be dealt with when trying to use it.
         }
-        return url.toExternalForm().endsWith("/");
+        String u = url.toExternalForm();
+        return u.endsWith("/") && !u.startsWith("jar:");
     }
 
     /**

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/Messages.properties
@@ -1,2 +1,3 @@
 ClasspathEntry.path.notExists=Specified path does not exist
 ClasspathEntry.path.notApproved=This classpath entry is not approved. Require an approval before execution.
+ClasspathEntry.path.noDirsAllowed=Class directories are not allowed as classpath entries.

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScriptTest.java
@@ -47,6 +47,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
 import java.io.File;
 import java.io.FileFilter;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
@@ -240,6 +241,25 @@ public class SecureGroovyScriptTest {
         }
         
         return ret;
+    }
+
+    private List<File> copy2TempDir(Iterable<File> files) throws IOException {
+        final File tempDir = tmpFolderRule.newFolder();
+        final List copies = new ArrayList<File>();
+        for (File f: files) {
+            final File copy = new File(tempDir, f.getName());
+            FileUtils.copyFile(f, copy);
+            copies.add(copy);
+        }
+        return copies;
+    }
+
+    private List<ClasspathEntry> files2entries(Iterable<File> files) throws IOException {
+        final List entries = new ArrayList<ClasspathEntry>();
+        for (File f: files) {
+            entries.add(new ClasspathEntry(f.toURI().toURL().toExternalForm()));
+        }
+        return entries;
     }
 
     private List<File> getAllUpdatedJarFiles() throws URISyntaxException {
@@ -567,68 +587,10 @@ public class SecureGroovyScriptTest {
             assertNotEquals(testingDisplayName, b.getDisplayName());
         }
         
-        // Approve classpath.
+        // Unable to approve classpath.
         {
             List<ScriptApproval.PendingClasspathEntry> pcps = ScriptApproval.get().getPendingClasspathEntries();
-            assertNotEquals(0, pcps.size());
-            for(ScriptApproval.PendingClasspathEntry pcp: pcps) {
-                ScriptApproval.get().approveClasspathEntry(pcp.getHash());
-            }
-        }
-        
-        // Success as approved.
-        {
-            FreeStyleBuild b = p.scheduleBuild2(0).get();
-            r.assertBuildStatusSuccess(b);
-            assertEquals(testingDisplayName, b.getDisplayName());
-        }
-        
-        // add new file in tmpDir.
-        {
-            File f = tmpFolderRule.newFile();
-            FileUtils.copyFileToDirectory(f, tmpDir);
-        }
-        
-        // Fail as the class directory is updated.
-        {
-            FreeStyleBuild b = p.scheduleBuild2(0).get();
-            r.assertBuildStatus(Result.FAILURE, b);
-            assertNotEquals(testingDisplayName, b.getDisplayName());
-        }
-        
-        // Approve classpath.
-        {
-            List<ScriptApproval.PendingClasspathEntry> pcps = ScriptApproval.get().getPendingClasspathEntries();
-            assertNotEquals(0, pcps.size());
-            for(ScriptApproval.PendingClasspathEntry pcp: pcps) {
-                ScriptApproval.get().approveClasspathEntry(pcp.getHash());
-            }
-        }
-        
-        // Success as approved.
-        {
-            FreeStyleBuild b = p.scheduleBuild2(0).get();
-            r.assertBuildStatusSuccess(b);
-            assertEquals(testingDisplayName, b.getDisplayName());
-        }
-        
-        // add a new file in a subdirectory of the tmpDir.
-        {
-            File f = tmpFolderRule.newFile();
-            File targetDir = tmpDir.listFiles(new FileFilter(){
-                public boolean accept(File pathname) {
-                    return pathname.isDirectory();
-                }
-                
-            })[0];
-            FileUtils.copyFileToDirectory(f, targetDir);
-        }
-        
-        // Should fail as the class directory is updated.
-        {
-            FreeStyleBuild b = p.scheduleBuild2(0).get();
-            r.assertBuildStatus(Result.FAILURE, b);
-            assertNotEquals(testingDisplayName, b.getDisplayName());
+            assertEquals(0, pcps.size());
         }
     }
     
@@ -643,17 +605,7 @@ public class SecureGroovyScriptTest {
         
         final String testingDisplayName = "TESTDISPLAYNAME";
         
-        File tmpDir1 = tmpFolderRule.newFolder();
-        
-        for (File jarfile: getAllJarFiles()) {
-            Expand e = new Expand();
-            e.setSrc(jarfile);
-            e.setDest(tmpDir1);
-            e.execute();
-        }
-        
-        List<ClasspathEntry> classpath1 = new ArrayList<ClasspathEntry>();
-        classpath1.add(new ClasspathEntry(tmpDir1.getAbsolutePath()));
+        final List<File> jars = getAllJarFiles();
         
         FreeStyleProject p1 = r.createFreeStyleProject();
         p1.getPublishersList().add(new TestGroovyRecorder(new SecureGroovyScript(
@@ -662,7 +614,7 @@ public class SecureGroovyScriptTest {
                         + "BuildUtil.setDisplayNameWhitelisted(build, \"%s\");"
                         + "\"\"", testingDisplayName),
                 true,
-                classpath1
+                files2entries(jars)
         )));
         
         // Fail as the classpath is not approved.
@@ -688,32 +640,7 @@ public class SecureGroovyScriptTest {
             assertEquals(testingDisplayName, b.getDisplayName());
         }
         
-        File tmpDir2 = tmpFolderRule.newFolder();
-        
-        for (File jarfile: getAllJarFiles()) {
-            Expand e = new Expand();
-            e.setSrc(jarfile);
-            e.setDest(tmpDir2);
-            e.execute();
-        }
-        
-        // touch all files.
-        {
-            DirectoryScanner ds = new DirectoryScanner();
-            ds.setBasedir(tmpDir2);
-            ds.setIncludes(new String[]{ "**" });
-            ds.scan();
-            
-            for (String relpath: ds.getIncludedFiles()) {
-                Touch t = new Touch();
-                t.setFile(new File(tmpDir2, relpath));
-                t.execute();
-            }
-        }
-        
-        List<ClasspathEntry> classpath2 = new ArrayList<ClasspathEntry>();
-        classpath2.add(new ClasspathEntry(tmpDir2.getAbsolutePath()));
-        
+        // New job with jars in other places.
         FreeStyleProject p2 = r.createFreeStyleProject();
         p2.getPublishersList().add(new TestGroovyRecorder(new SecureGroovyScript(
                 String.format(
@@ -721,7 +648,7 @@ public class SecureGroovyScriptTest {
                         + "BuildUtil.setDisplayNameWhitelisted(build, \"%s\");"
                         + "\"\"", testingDisplayName),
                 true,
-                classpath2
+                files2entries(copy2TempDir(jars))
         )));
         
         // Success as approved.

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntryTest.java
@@ -44,7 +44,7 @@ public class ClasspathEntryTest {
         } else {
             assertRoundTrip("C:\\tmp\\x.jar", "file:/C:/tmp/x.jar");
         }
-        assertEquals("jar:file:/tmp/x.jar!/subjar.jar", "jar:file:/tmp/x.jar!/subjar.jar");
+        assertRoundTrip("jar:file:/tmp/x.jar!/subjar.jar", "jar:file:/tmp/x.jar!/subjar.jar");
     }
 
     private static void assertRoundTrip(String path, String url) throws Exception {


### PR DESCRIPTION
See [JENKINS-24399](https://issues.jenkins-ci.org/browse/JENKINS-24399).

Proposed solution after the discussion in the issue is removing the possibility of using class folder as classpath entries.

Includes https://github.com/jenkinsci/script-security-plugin/pull/4

@reviewbybees 