### PR TITLE
allow toList methods

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -159,6 +159,17 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods size java.lang.Str
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods size long[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods size short[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toInteger java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList Iterable
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList boolean[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList byte[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList char[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList double[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList float[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList int[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.util.Enumeration
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.util.Iterator
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList long[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList short[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods tokenize java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods tokenize java.lang.String java.lang.Character
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods tokenize java.lang.String java.lang.String


### PR DESCRIPTION
Whitelist staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList variants since they are very useful and harmless
