### PR TITLE
Blacklist new java.io.FileInputStream java.lang.String

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/blacklist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/blacklist
@@ -9,6 +9,7 @@ method groovy.lang.GroovyObject setProperty java.lang.String java.lang.Object
 new java.io.File java.lang.String
 new java.io.File java.lang.String java.lang.String
 new java.io.File java.net.URI
+new java.io.FileInputStream java.lang.String
 
 # Same for local process execution.
 staticMethod java.lang.Runtime getRuntime


### PR DESCRIPTION
Saw someone trying to use this from a `Jenkinsfile`. It is dangerous, and usually better done with `readFile`.

The constructor overload taking `File` is not a thread because we are already blacklisting the `File` constructors.

@reviewbybees