### PR TITLE
[JENKINS-34466] Fix PCT against 2.0

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/GenericWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/GenericWhitelist.java
@@ -35,8 +35,14 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class)
 @Extension public final class GenericWhitelist extends ProxyWhitelist {
 
+    private static StaticWhitelist load(String name) throws IOException {
+        return StaticWhitelist.from(GenericWhitelist.class.getResource(name));
+    }
+
     public GenericWhitelist() throws IOException {
-        super(StaticWhitelist.from(GenericWhitelist.class.getResource("generic-whitelist")));
+        super(load("generic-whitelist"), load("generic-whitelist-groovy2"));
+        // it should be safe to load the Grrovy 2 at this, those signatures should not
+        // be reached if groovy 1 is in the classpath
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
@@ -43,16 +43,17 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import groovy.lang.GroovySystem;
+import hudson.util.VersionNumber;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
 
 /**
  * Whitelist based on a static file.
  */
 public final class StaticWhitelist extends EnumeratingWhitelist {
-    private static final String G2_PREFIX = "g2";
-    private static final boolean GROOVY2 = GroovySystem.getVersion().startsWith("2.");
+    static final boolean GROOVY2 = new VersionNumber(GroovySystem.getVersion()).compareTo(new VersionNumber("2")) >= 0;
 
     final List<MethodSignature> methodSignatures = new ArrayList<MethodSignature>();
     final List<NewSignature> newSignatures = new ArrayList<NewSignature>();
@@ -86,21 +87,10 @@ public final class StaticWhitelist extends EnumeratingWhitelist {
      * @param line Line to filter.
      * @return {@code null} if the like must be skipped or the content to process if not.
      */
-    static String filter(String line) {
-        if (line == null) {
-            return null;
-        }
+    static @CheckForNull String filter(@Nonnull String line) {
         line = line.trim();
         if (line.isEmpty() || line.startsWith("#")) {
             return null;
-        }
-        if (line.startsWith(G2_PREFIX)) {
-            if (GROOVY2) {
-                return line.substring(G2_PREFIX.length()).trim();
-                // If empty or malformed after the prefix, we'll leave the parsing fail.
-            } else {
-                return null; // skip
-            }
         }
         return line;
     }

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.scriptsecurity.scripts;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -756,6 +757,16 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
         return pendingSignatures;
     }
 
+    // Added to account for new findbugs annotations in ExtensionList#get (PCT scenario)
+    private String[][] reconfigure(@NonNull Jenkins jenkins) throws IOException {
+        final ApprovedWhitelist awl = jenkins.getExtensionList(Whitelist.class).get(ApprovedWhitelist.class);
+        if (awl != null) {
+            return awl.reconfigure();
+        } else {
+            return new String[][] {new String[0], new String[0]};
+        }
+    }
+
     @Restricted(NoExternalUse.class) // for use from AJAX
     @JavaScriptMethod public synchronized String[][] approveSignature(String signature) throws IOException {
         final Jenkins jenkins = getJenkins();
@@ -763,7 +774,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
         pendingSignatures.remove(new PendingSignature(signature, false, ApprovalContext.create()));
         approvedSignatures.add(signature);
         save();
-        return jenkins.getExtensionList(Whitelist.class).get(ApprovedWhitelist.class).reconfigure();
+        return reconfigure(jenkins);
     }
 
     @Restricted(NoExternalUse.class) // for use from AJAX
@@ -773,7 +784,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
         pendingSignatures.remove(new PendingSignature(signature, false, ApprovalContext.create()));
         aclApprovedSignatures.add(signature);
         save();
-        return jenkins.getExtensionList(Whitelist.class).get(ApprovedWhitelist.class).reconfigure();
+        return reconfigure(jenkins);
     }
 
     @Restricted(NoExternalUse.class) // for use from AJAX
@@ -793,7 +804,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
         aclApprovedSignatures.clear();
         save();
         // Should be [[], []] but still returning it for consistency with approve methods.
-        return jenkins.getExtensionList(Whitelist.class).get(ApprovedWhitelist.class).reconfigure();
+        return reconfigure(jenkins);
     }
 
     @Restricted(NoExternalUse.class)

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -127,7 +127,14 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods asBoolean java.lan
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.lang.Object groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Collection groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods disjoint java.util.Collection java.util.Collection
+g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Iterable groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Object groovy.lang.Closure
+g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Collection groovy.lang.Closure
+g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Iterator groovy.lang.Closure
+g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.List groovy.lang.Closure
+g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Map groovy.lang.Closure
+g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Set groovy.lang.Closure
+g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.SortedSet groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachLine java.lang.CharSequence groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachLine java.lang.CharSequence int groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachLine java.lang.String groovy.lang.Closure
@@ -145,6 +152,7 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join java.util.Col
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods last java.lang.Object[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods last java.util.List
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Collection java.lang.Object
+g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.List java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods or java.lang.Boolean java.lang.Boolean
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.lang.CharSequence java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.lang.Number java.lang.String

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -127,14 +127,7 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods asBoolean java.lan
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.lang.Object groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Collection groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods disjoint java.util.Collection java.util.Collection
-g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Iterable groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Object groovy.lang.Closure
-g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Collection groovy.lang.Closure
-g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Iterator groovy.lang.Closure
-g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.List groovy.lang.Closure
-g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Map groovy.lang.Closure
-g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Set groovy.lang.Closure
-g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.SortedSet groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachLine java.lang.CharSequence groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachLine java.lang.CharSequence int groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachLine java.lang.String groovy.lang.Closure
@@ -152,7 +145,6 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join java.util.Col
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods last java.lang.Object[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods last java.util.List
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Collection java.lang.Object
-g2 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.List java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods or java.lang.Boolean java.lang.Boolean
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.lang.CharSequence java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.lang.Number java.lang.String

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist-groovy2
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist-groovy2
@@ -1,0 +1,9 @@
+# Groovy 2 additional overloads
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Set groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.SortedSet groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.List java.lang.Object

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/GenericWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/GenericWhitelistTest.java
@@ -29,7 +29,8 @@ import org.junit.Test;
 public class GenericWhitelistTest {
     
     @Test public void sanity() throws Exception {
-        StaticWhitelistTest.sanity(GenericWhitelist.class.getResource("generic-whitelist"));
+        StaticWhitelistTest.sanity(GenericWhitelist.class.getResource("generic-whitelist"), true);
+        StaticWhitelistTest.sanity(GenericWhitelist.class.getResource("generic-whitelist-groovy2"), StaticWhitelist.GROOVY2);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/JenkinsWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/JenkinsWhitelistTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class JenkinsWhitelistTest {
     
     @Test public void sanity() throws Exception {
-        StaticWhitelistTest.sanity(JenkinsWhitelist.class.getResource("jenkins-whitelist"));
+        StaticWhitelistTest.sanity(JenkinsWhitelist.class.getResource("jenkins-whitelist"), true);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
@@ -53,8 +53,8 @@ public class StaticWhitelistTest {
             BufferedReader br = new BufferedReader(new InputStreamReader(is, "UTF-8"));
             String line;
             while ((line = br.readLine()) != null) {
-                line = line.trim();
-                if (line.isEmpty() || line.startsWith("#")) {
+                line = StaticWhitelist.filter(line);
+                if (line == null) {
                     continue;
                 }
                 sigs.add(StaticWhitelist.parse(line));

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
@@ -45,7 +45,7 @@ public class StaticWhitelistTest {
         assertTrue(StaticWhitelist.rejectMethod(GroovyObject.class.getMethod("invokeMethod", String.class, Object.class)).isDangerous());
     }
 
-    static void sanity(URL definition) throws Exception {
+    static void sanity(URL definition, boolean checkExists) throws Exception {
         StaticWhitelist wl = StaticWhitelist.from(definition);
         List<EnumeratingWhitelist.Signature> sigs = new ArrayList<EnumeratingWhitelist.Signature>();
         InputStream is = definition.openStream();
@@ -63,17 +63,19 @@ public class StaticWhitelistTest {
             is.close();
         }
         assertEquals("entries in " + definition + " should be sorted and unique", new TreeSet<EnumeratingWhitelist.Signature>(sigs).toString(), sigs.toString());
-        for (EnumeratingWhitelist.Signature sig : sigs) {
-            try {
-                assertTrue(sig + " does not exist (or is an override)", sig.exists());
-            } catch (ClassNotFoundException x) {
-                System.err.println("Cannot check validity of `" + sig + "` due to " + x);
+        if (checkExists) {
+            for (EnumeratingWhitelist.Signature sig : sigs) {
+                try {
+                    assertTrue(sig + " does not exist (or is an override)", sig.exists());
+                } catch (ClassNotFoundException x) {
+                    System.err.println("Cannot check validity of `" + sig + "` due to " + x);
+                }
             }
         }
     }
 
     @Test public void sanity() throws Exception {
-        sanity(StaticWhitelist.class.getResource("blacklist"));
+        sanity(StaticWhitelist.class.getResource("blacklist"), true);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/AbstractApprovalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/AbstractApprovalTest.java
@@ -39,13 +39,9 @@ public abstract class AbstractApprovalTest<T extends Approvable<T>> {
         create().use();
     }
 
-    @Test public void withSecurityRejected() throws Exception {
+    @Test public void withSecurity() throws Exception {
         configureSecurity();
-        create().assertCannotUse();
-    }
-
-    @Test public void withSecurityAccepted() throws Exception {
-        configureSecurity();
+        // Cannot use until approved
         create().assertCannotUse().approve().use();
     }
 


### PR DESCRIPTION
When building against Jenkins 2.0 Groovy 2.4.6 is used instead of 1.8.9 in the baseline. This brings a couple of issues:
* For some methods in the whitelist there are additional overloads for more specific type arguments, generating approval errors.
* The behavior for ambiguous overloading has changed: no longer "some" version of the method is picked but an exception is thrown.

Besides, the PR includes:
* Findbugs fixes when building against 2.0
* Some cleanup after https://github.com/jenkinsci/script-security-plugin/pull/53

@reviewbybees 