### PR TITLE
Blacklisting RunWrapper.getRawBuild

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/blacklist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/blacklist
@@ -22,3 +22,6 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods execute java.lang.
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods execute java.util.List
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods execute java.util.List java.lang.String[] java.io.File
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods execute java.util.List java.util.List java.io.File
+
+# TODO do we need a @Blacklisted annotation?
+method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild


### PR DESCRIPTION
`currentBuild.rawBuild` is not in and of itself a risk in a Pipeline script, but pretty much anything you would do with the result would be, so best to nip this in the bud.

@reviewbybees