### PR TITLE
[JENKINS-37599] Prevent empty classpath entries from being saved accidentally

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntry.java
@@ -68,7 +68,7 @@ public final class ClasspathEntry extends AbstractDescribableImpl<ClasspathEntry
             if (f.isAbsolute()) {
                 return f.toURI().toURL();
             } else {
-                throw new MalformedURLException("classpath entries must be URLs or absolute file paths");
+                throw new MalformedURLException("Classpath entry ‘" + path + "’ does not look like either a URL or an absolute file path");
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntry.java
@@ -58,10 +58,18 @@ public final class ClasspathEntry extends AbstractDescribableImpl<ClasspathEntry
     }
     
     static URL pathToURL(String path) throws MalformedURLException {
+        if (path.isEmpty()) {
+            throw new MalformedURLException("JENKINS-37599: empty classpath entries not allowed");
+        }
         try {
             return new URL(path);
         } catch (MalformedURLException x) {
-            return new File(path).toURI().toURL();
+            File f = new File(path);
+            if (f.isAbsolute()) {
+                return f.toURI().toURL();
+            } else {
+                throw new MalformedURLException("classpath entries must be URLs or absolute file paths");
+            }
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntryTest.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.scriptsecurity.scripts;
 import hudson.Functions;
 
 import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.junit.Rule;
@@ -34,6 +35,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.*;
+import org.jvnet.hudson.test.Issue;
 
 public class ClasspathEntryTest {
     @Rule public TemporaryFolder rule = new TemporaryFolder();
@@ -63,6 +65,31 @@ public class ClasspathEntryTest {
         assertTrue("Non-existing file is considered class directory if ending in /", ClasspathEntry.isClassDirectoryURL(oneDir));
         assertTrue("Generic URLs ending in / are considered class directories", ClasspathEntry.isClassDirectoryURL(new URL("http://example.com/folder/")));
         assertFalse("Generic URLs ending in / are not considered class directories", ClasspathEntry.isClassDirectoryURL(new URL("http://example.com/file")));
+    }
+
+    @Issue("JENKINS-37599")
+    @Test public void pathToURL() throws Exception {
+        ClasspathEntry ignore = new ClasspathEntry("http://nowhere.net/");
+        ignore = new ClasspathEntry(rule.newFile("x.jar").getAbsolutePath());
+        ignore = new ClasspathEntry(rule.newFolder().getAbsolutePath());
+        try {
+            ignore = new ClasspathEntry("");
+            fail();
+        } catch (MalformedURLException x) {
+            // good
+        }
+        try {
+            ignore = new ClasspathEntry(" ");
+            fail();
+        } catch (MalformedURLException x) {
+            // good
+        }
+        try {
+            ignore = new ClasspathEntry("relative");
+            fail();
+        } catch (MalformedURLException x) {
+            // good
+        }
     }
 
 }


### PR DESCRIPTION
[JENKINS-37599](https://issues.jenkins-ci.org/browse/JENKINS-37599)

At least makes the problem clearer.

@reviewbybees