### PR TITLE
Whitelist Objects.requireNonNull methods

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -136,6 +136,8 @@ method java.util.Map putAll java.util.Map
 method java.util.Map values
 method java.util.Map$Entry getKey
 method java.util.Map$Entry getValue
+staticMethod java.util.Objects requireNonNull java.lang.Object
+staticMethod java.util.Objects requireNonNull java.lang.Object java.lang.String
 staticMethod java.util.TimeZone getTimeZone java.lang.String
 staticMethod java.util.UUID randomUUID
 method java.util.concurrent.Callable call


### PR DESCRIPTION
These are useful for writing methods/functions that want to check input.
They can also be useful for providing folder-scoped "global" libraries since those must pass security restricitons.

----

#### Open question

After making this change it made me wonder, does the `script-security-plugin` care about language version? There are also some Java 8 methods (since we run Jenkins on Java 8) that would be very useful for us to generically whitelist in this plugin.
