### PR TITLE
Add HTML encoding/decoding of strings to whitelist

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -80,6 +80,8 @@ method java.lang.String trim
 staticMethod java.lang.System currentTimeMillis
 method java.lang.Throwable getMessage
 new java.net.URL java.lang.String
+staticMethod java.net.URLDecoder decode java.lang.String java.lang.String
+staticMethod java.net.URLEncoder encode java.lang.String java.lang.String
 staticMethod java.util.Arrays toString java.lang.Object[]
 staticField java.util.Calendar AM_PM
 staticField java.util.Calendar DATE


### PR DESCRIPTION
We're using the BUILD_TAG to get unique but trackable and predictable names for our docker tags during some CI processes.

Unfortunately this results in a %25 (/) in being presented when there is a branch with '/' in the name (via the bitbucket source plugin which puts branches in folders of repos in folders of projects), which is of course invalid as a docker tag character... and we have bumped into similar ones too

It'd be very useful when processing much of this stuff to be able to encode and decode between string and html encoding form without having to manually whitelist the method.

Could the methods please be added to the generic whitelist
