### PR TITLE
Whitelist Map.plus and Map.leftShift for the benefit of Jenkins/Groov…

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist-groovy2
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist-groovy2
@@ -9,3 +9,5 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Sor
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.List java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.util.List java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods unique java.util.List
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Map java.util.Map
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.util.Map java.util.Map


### PR DESCRIPTION
Allow `Map.plus()` and `Map.leftshift()` default.
```groovy
Map conf = [:]
Map defaultConf = [k1:v1, k2:v2]

Map mergedConf = defaultConf + conf  // this should be working
defaultConf << conf  // this should be also working
```