### PR TITLE
Added GroovyStringMethods.find to Whitelist

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -64,6 +64,7 @@ method java.lang.String endsWith java.lang.String
 method java.lang.String indexOf java.lang.String
 method java.lang.String lastIndexOf java.lang.String
 method java.lang.String matches java.lang.String
+method java.lang.String find java.lang.String
 method java.lang.String replace char char
 method java.lang.String replace java.lang.CharSequence java.lang.CharSequence
 method java.lang.String replaceAll java.lang.String java.lang.String

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -61,10 +61,10 @@ method java.lang.Object getClass
 method java.lang.Object toString
 method java.lang.String contains java.lang.CharSequence
 method java.lang.String endsWith java.lang.String
+method java.lang.String find java.lang.String
 method java.lang.String indexOf java.lang.String
 method java.lang.String lastIndexOf java.lang.String
 method java.lang.String matches java.lang.String
-method java.lang.String find java.lang.String
 method java.lang.String replace char char
 method java.lang.String replace java.lang.CharSequence java.lang.CharSequence
 method java.lang.String replaceAll java.lang.String java.lang.String

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -61,7 +61,6 @@ method java.lang.Object getClass
 method java.lang.Object toString
 method java.lang.String contains java.lang.CharSequence
 method java.lang.String endsWith java.lang.String
-method java.lang.String find java.lang.String
 method java.lang.String indexOf java.lang.String
 method java.lang.String lastIndexOf java.lang.String
 method java.lang.String matches java.lang.String
@@ -255,3 +254,7 @@ staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter compareTo java.la
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter findRegex java.lang.Object java.lang.Object
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter isCase java.lang.Object java.lang.Object
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter matchRegex java.lang.Object java.lang.Object
+staticMethod org.codehaus.groovy.runtime.StringGroovyMethods find java.lang.CharSequence java.lang.CharSequence
+staticMethod org.codehaus.groovy.runtime.StringGroovyMethods find java.lang.CharSequence java.lang.CharSequence groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.StringGroovyMethods find java.lang.CharSequence java.util.regex.Pattern
+staticMethod org.codehaus.groovy.runtime.StringGroovyMethods find java.lang.CharSequence java.util.regex.Pattern groovy.lang.Closure


### PR DESCRIPTION
Add String.find to the generic whitelist since matches is whitelisted and it is literally the same