### PR TITLE
Revert minimal required version back to 1.609.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 target
 work
 
-.idea
+.*
+!.gitignore
+
 *.iml

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,10 @@
     <packaging>hpi</packaging>
     <name>Script Security Plugin</name>
     <description>Allows Jenkins administrators to control what in-process scripts can be run by less-privileged users.</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Plugin</url> 
+    <url>https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Plugin</url>
     <properties>
-      <jenkins.version>1.625.3</jenkins.version>
+      <java.level>7</java.level>
+      <jenkins.version>1.609.3</jenkins.version>
     </properties>
     <licenses>
         <license>


### PR DESCRIPTION
It is great #106 got released but I can not use it on 1.609. The codebase does not seem to rely on newer Jenkins version - Java 7 seems enough.