### PR TITLE
[FIXED JENKINS-34741] Allow new Class(foo: bar) to work.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -163,6 +164,18 @@ class GroovyCallSiteSelector {
                 return c;
             }
         }
+
+        // Only check for the magic Map constructor if we haven't already found a real constructor.
+        // Also note that this logic is derived from how Groovy itself decides to use the magic Map constructor, at
+        // MetaClassImpl#invokeConstructor(Class, Object[]).
+        if (args.length == 1 && args[0] instanceof Map) {
+            for (Constructor<?> c : receiver.getDeclaredConstructors()) {
+                if (c.getParameterTypes().length == 0 && !c.isVarArgs()) {
+                    return c;
+                }
+            }
+        }
+
         return null;
     }
 

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -328,7 +328,6 @@ public class SandboxInterceptorTest {
         assertRejected(new AnnotatedWhitelist(), "staticMethod " + clazz + " explode", "C.m(); class C {static void m() {" + clazz + ".explode();}}");
     }
 
-    @Ignore("TODO RejectedAccessException: unclassified new C java.util.LinkedHashMap")
     @Issue("JENKINS-34741")
     @Test public void structConstructor() throws Exception {
         assertEvaluate(new StaticWhitelist(), "ok", "class C {String f}; new C(f: 'ok').f");


### PR DESCRIPTION
[JENKINS-34741](https://issues.jenkins-ci.org/browse/JENKINS-34741)

Adds logic derived from Groovy's MetaClassImpl#invokeConstructor
method to return the no-parameters constructor when no matching
declared constructor is found, there's one argument, and that one
argument is a Map.

cc @reviewbybees 