### PR TITLE
Allow toList() returning a Collection

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -267,6 +267,7 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList double[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList float[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList int[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.lang.Iterable
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.util.Collection
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.util.Enumeration
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.util.Iterator
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList long[]


### PR DESCRIPTION
To allow that kind of deduplication (found `.unique()` in the meantime, but I think this method should be still be allowed, as this seems harmless)

 ```groovy
def variable = ['a', 'b', 'a']
variable = variable.toSet().toList()
```

@reviewbybees 