### PR TITLE
Adding whitelist methods needed for DefaultGroovyMethods

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -20,7 +20,6 @@ method groovy.json.JsonSlurper parseText java.lang.String
 method groovy.lang.Binding hasVariable java.lang.String
 staticField groovy.lang.Closure DELEGATE_FIRST
 staticField groovy.lang.Closure DELEGATE_ONLY
-staticField groovy.lang.Closure DONE
 staticField groovy.lang.Closure OWNER_FIRST
 staticField groovy.lang.Closure OWNER_ONLY
 staticField groovy.lang.Closure TO_SELF
@@ -29,19 +28,13 @@ method groovy.lang.Closure call java.lang.Object[]
 method groovy.lang.Closure curry java.lang.Object
 method groovy.lang.Closure curry java.lang.Object[]
 method groovy.lang.Closure getDelegate
-method groovy.lang.Closure getDirective
-method groovy.lang.Closure getMaximumNumberOfParameters
 method groovy.lang.Closure getResolveStrategy
 method groovy.lang.Closure ncurry int java.lang.Object
 method groovy.lang.Closure ncurry int java.lang.Object[]
 method groovy.lang.Closure setDelegate java.lang.Object
 method groovy.lang.Closure setResolveStrategy int
 method groovy.lang.GString plus java.lang.String
-staticMethod groovy.lang.ListWithDefault newInstance java.util.List boolean groovy.lang.Closure
-staticMethod groovy.lang.MapWithDefault newInstance java.util.Map groovy.lang.Closure
 method groovy.lang.Script getBinding
-staticMethod groovy.util.GroovyCollections combinations java.util.Collection
-new groovy.util.PermutationGenerator java.util.Collection
 
 # Needed for Groovy Templates to emit output:
 method java.io.PrintWriter print java.lang.Object
@@ -57,9 +50,6 @@ staticMethod java.lang.Boolean valueOf java.lang.String
 method java.lang.CharSequence charAt int
 method java.lang.CharSequence length
 method java.lang.Class getName
-method java.lang.Class getSimpleName
-method java.lang.Class isArray
-method java.lang.Class isInstance java.lang.Object
 method java.lang.Comparable compareTo java.lang.Object
 method java.lang.Enum name
 method java.lang.Enum ordinal
@@ -99,7 +89,6 @@ method java.lang.String toUpperCase
 method java.lang.String toUpperCase java.util.Locale
 method java.lang.String trim
 staticMethod java.lang.String valueOf java.lang.Object
-staticMethod java.lang.System arraycopy java.lang.Object int java.lang.Object int int
 staticMethod java.lang.System currentTimeMillis
 method java.lang.Throwable getMessage
 new java.net.MalformedURLException java.lang.String
@@ -108,10 +97,7 @@ staticMethod java.net.URLDecoder decode java.lang.String java.lang.String
 staticMethod java.net.URLEncoder encode java.lang.String java.lang.String
 method java.text.Format format java.lang.Object
 new java.text.SimpleDateFormat java.lang.String
-new java.util.ArrayList
-new java.util.ArrayList int
 new java.util.ArrayList java.util.Collection
-staticMethod java.util.Arrays asList java.lang.Object[]
 staticMethod java.util.Arrays toString java.lang.Object[]
 staticField java.util.Calendar AM_PM
 staticField java.util.Calendar DATE
@@ -146,8 +132,6 @@ new java.util.Date long
 new java.util.HashSet
 method java.util.Iterator hasNext
 method java.util.Iterator next
-method java.util.Iterator remove
-new java.util.LinkedHashMap
 method java.util.List get int
 staticField java.util.Locale CANADA
 staticField java.util.Locale CANADA_FRENCH
@@ -388,7 +372,6 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimil
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarCollection java.util.Collection int
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarMap java.util.Map
 staticMethod org.codehaus.groovy.runtime.InvokerHelper asIterator java.lang.Object
-new org.codehaus.groovy.runtime.ReverseListIterator java.util.List
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter castToType java.lang.Object java.lang.Class
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter compareEqual java.lang.Object java.lang.Object
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter compareGreaterThan java.lang.Object java.lang.Object
@@ -434,7 +417,3 @@ staticMethod org.codehaus.groovy.runtime.StringGroovyMethods tr java.lang.CharSe
 staticMethod org.codehaus.groovy.runtime.StringGroovyMethods unexpand java.lang.CharSequence
 staticMethod org.codehaus.groovy.runtime.StringGroovyMethods unexpand java.lang.CharSequence int
 staticMethod org.codehaus.groovy.runtime.StringGroovyMethods unexpandLine java.lang.CharSequence int
-method org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper call java.lang.Object[]
-method org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper callForMap java.util.Map$Entry
-new org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper groovy.lang.Closure
-new org.codehaus.groovy.util.ArrayIterator java.lang.Object[]

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -1,5 +1,168 @@
-# groovy-cps
+# groovy-cps - not needed from workflow-cps 2.33+
 staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods each java.util.Iterator groovy.lang.Closure
+
+# Groovy default methods and other methods/classes needed to enable them.
+method groovy.lang.Closure getDirective
+method groovy.lang.Closure getMaximumNumberOfParameters
+method java.lang.Class getSimpleName
+method java.lang.Class isArray
+method java.lang.Class isInstance java.lang.Object
+method java.util.Iterator remove
+method org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper call java.lang.Object[]
+method org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper callForMap java.util.Map$Entry
+new groovy.util.PermutationGenerator java.util.Collection
+new java.util.ArrayList
+new java.util.ArrayList int
+new java.util.LinkedHashMap
+new org.codehaus.groovy.runtime.ReverseListIterator java.util.List
+new org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper groovy.lang.Closure
+new org.codehaus.groovy.util.ArrayIterator java.lang.Object[]
+staticField groovy.lang.Closure DONE
+staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $addEntry__java_util_Map__java_lang_Object java.util.Map java.lang.Object
+staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $callClosureForMapEntryAndCounter__groovy_lang_Closure__java_util_Map_Entry__int groovy.lang.Closure java.util.Map$Entry int
+staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $callClosureForMapEntry__groovy_lang_Closure__java_util_Map_Entry groovy.lang.Closure java.util.Map$Entry
+staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $groupAnswer__java_util_Map__java_lang_Object__java_lang_Object java.util.Map java.lang.Object java.lang.Object
+staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $split__groovy_lang_Closure__java_util_Collection__java_util_Collection__java_util_Iterator groovy.lang.Closure java.util.Collection java.util.Collection java.util.Iterator
+staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $sum__java_lang_Iterable__java_lang_Object__groovy_lang_Closure__boolean java.lang.Iterable java.lang.Object groovy.lang.Closure boolean
+staticMethod groovy.lang.ListWithDefault newInstance java.util.List boolean groovy.lang.Closure
+staticMethod groovy.lang.MapWithDefault newInstance java.util.Map groovy.lang.Closure
+staticMethod groovy.util.GroovyCollections combinations java.util.Collection
+staticMethod java.lang.System arraycopy java.lang.Object int java.lang.Object int int
+staticMethod java.util.Arrays asList java.lang.Object[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods any java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods any java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Collection java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Map java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.lang.Iterable java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.lang.Object[] java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Collection java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Iterator java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Map java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.lang.Iterable java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.util.Collection java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.util.Map java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectNested java.lang.Iterable java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectNested java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectNested java.util.Collection java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods combinations java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.lang.Object[] java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.util.Collection java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countAnswer java.util.Map java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Set groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.SortedSet groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachPermutation java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.Set groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.SortedSet groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods every java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods every java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods every java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods find java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods find java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods find java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll groovy.lang.Closure java.util.Collection java.util.Iterator
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.util.Set groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findIndexOf java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findIndexOf java.lang.Object int groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findIndexValues java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findIndexValues java.lang.Object java.lang.Number groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findLastIndexOf java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findLastIndexOf java.lang.Object int groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResult java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResult java.util.Collection java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResult java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResult java.util.Map java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResults java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResults java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods flatten java.lang.Iterable java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods flatten java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupAnswer java.util.Map java.lang.Object java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.lang.Iterable java.lang.Object[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.lang.Object[] java.lang.Object[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.util.Collection java.lang.Object[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.util.Map java.lang.Object[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupEntriesBy java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.lang.Object[] java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.Collection java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.Iterator java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.Map java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods iterator java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Set java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods max java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods max java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods max java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods min java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods min java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods min java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods permutations java.util.List
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods permutations java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods putAll java.util.Map java.util.Collection
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods removeAll java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods retainAll java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverse java.util.Iterator
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverseEach java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverseEach java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverseEach java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split groovy.lang.Closure java.util.Collection java.util.Collection java.util.Iterator
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.util.Set groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.lang.Iterable java.lang.Object groovy.lang.Closure boolean
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.lang.Object[] java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.util.Collection
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.util.Collection java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods tail java.util.List
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.lang.Object[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods withDefault java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods withDefault java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods withLazyDefault java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarCollection java.util.Collection
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarCollection java.util.Collection int
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarMap java.util.Map
+staticMethod org.codehaus.groovy.runtime.InvokerHelper getMetaClass java.lang.Object
+staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter createRange java.lang.Object java.lang.Object boolean
 
 # Groovy:
 staticMethod groovy.json.JsonOutput prettyPrint java.lang.String

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -1,168 +1,14 @@
 # groovy-cps - not needed from workflow-cps 2.33+
-staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods each java.util.Iterator groovy.lang.Closure
-
-# Groovy default methods and other methods/classes needed to enable them.
-method groovy.lang.Closure getDirective
-method groovy.lang.Closure getMaximumNumberOfParameters
-method java.lang.Class getSimpleName
-method java.lang.Class isArray
-method java.lang.Class isInstance java.lang.Object
-method java.util.Iterator remove
-method org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper call java.lang.Object[]
-method org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper callForMap java.util.Map$Entry
-new groovy.util.PermutationGenerator java.util.Collection
-new java.util.ArrayList
-new java.util.ArrayList int
-new java.util.LinkedHashMap
-new org.codehaus.groovy.runtime.ReverseListIterator java.util.List
-new org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper groovy.lang.Closure
-new org.codehaus.groovy.util.ArrayIterator java.lang.Object[]
-staticField groovy.lang.Closure DONE
 staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $addEntry__java_util_Map__java_lang_Object java.util.Map java.lang.Object
 staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $callClosureForMapEntryAndCounter__groovy_lang_Closure__java_util_Map_Entry__int groovy.lang.Closure java.util.Map$Entry int
 staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $callClosureForMapEntry__groovy_lang_Closure__java_util_Map_Entry groovy.lang.Closure java.util.Map$Entry
+staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $countAnswer__java_util_Map__java_lang_Object java.util.Map java.lang.Object
+staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $findAll__groovy_lang_Closure__java_util_Collection__java_util_Iterator groovy.lang.Closure java.util.Collection java.util.Iterator
+staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $flatten__java_lang_Iterable__java_util_Collection__groovy_lang_Closure java.lang.Iterable java.util.Collection groovy.lang.Closure
 staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $groupAnswer__java_util_Map__java_lang_Object__java_lang_Object java.util.Map java.lang.Object java.lang.Object
 staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $split__groovy_lang_Closure__java_util_Collection__java_util_Collection__java_util_Iterator groovy.lang.Closure java.util.Collection java.util.Collection java.util.Iterator
 staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods $sum__java_lang_Iterable__java_lang_Object__groovy_lang_Closure__boolean java.lang.Iterable java.lang.Object groovy.lang.Closure boolean
-staticMethod groovy.lang.ListWithDefault newInstance java.util.List boolean groovy.lang.Closure
-staticMethod groovy.lang.MapWithDefault newInstance java.util.Map groovy.lang.Closure
-staticMethod groovy.util.GroovyCollections combinations java.util.Collection
-staticMethod java.lang.System arraycopy java.lang.Object int java.lang.Object int int
-staticMethod java.util.Arrays asList java.lang.Object[]
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods any java.lang.Iterable groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods any java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Collection java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Map java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.lang.Iterable java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.lang.Object[] java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Collection java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Iterator groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Iterator java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Map java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.lang.Iterable groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.lang.Iterable java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.util.Collection java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.util.Map java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectNested java.lang.Iterable java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectNested java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectNested java.util.Collection java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods combinations java.lang.Iterable groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.lang.Iterable groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.lang.Object[] java.lang.Object
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.util.Collection java.lang.Object
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.util.Iterator groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countAnswer java.util.Map java.lang.Object
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.lang.Iterable groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.util.Iterator groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Iterator groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Set groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.SortedSet groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachPermutation java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.lang.Iterable groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.Iterator groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.List groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.Set groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.SortedSet groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods every java.lang.Iterable groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods every java.util.Iterator groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods every java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods find java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods find java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods find java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll groovy.lang.Closure java.util.Collection java.util.Iterator
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.util.List groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.util.Set groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findIndexOf java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findIndexOf java.lang.Object int groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findIndexValues java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findIndexValues java.lang.Object java.lang.Number groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findLastIndexOf java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findLastIndexOf java.lang.Object int groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResult java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResult java.util.Collection java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResult java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResult java.util.Map java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResults java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResults java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods flatten java.lang.Iterable java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods flatten java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupAnswer java.util.Map java.lang.Object java.lang.Object
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.lang.Iterable groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.lang.Iterable java.lang.Object[]
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.lang.Object[] java.lang.Object[]
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.util.Collection java.lang.Object[]
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.util.Map java.lang.Object[]
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupEntriesBy java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.lang.Object[] java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.Collection java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.Iterator java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.Map java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods iterator java.lang.Object
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Set java.lang.Object
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods max java.lang.Iterable groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods max java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods max java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods min java.lang.Iterable groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods min java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods min java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods permutations java.util.List
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods permutations java.util.List groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods putAll java.util.Map java.util.Collection
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods removeAll java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods retainAll java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverse java.util.Iterator
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverseEach java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverseEach java.util.List groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverseEach java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split groovy.lang.Closure java.util.Collection java.util.Collection java.util.Iterator
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.util.List groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.util.Set groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.lang.Iterable java.lang.Object groovy.lang.Closure boolean
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.lang.Object[] groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.lang.Object[] java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.util.Collection
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.util.Collection groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.util.Collection java.lang.Object groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods tail java.util.List
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.lang.Object[]
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.lang.String
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods withDefault java.util.List groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods withDefault java.util.Map groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods withLazyDefault java.util.List groovy.lang.Closure
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarCollection java.util.Collection
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarCollection java.util.Collection int
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarMap java.util.Map
-staticMethod org.codehaus.groovy.runtime.InvokerHelper getMetaClass java.lang.Object
-staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter createRange java.lang.Object java.lang.Object boolean
+staticMethod com.cloudbees.groovy.cps.CpsDefaultGroovyMethods each java.util.Iterator groovy.lang.Closure
 
 # Groovy:
 staticMethod groovy.json.JsonOutput prettyPrint java.lang.String
@@ -183,6 +29,7 @@ method groovy.json.JsonSlurper parseText java.lang.String
 method groovy.lang.Binding hasVariable java.lang.String
 staticField groovy.lang.Closure DELEGATE_FIRST
 staticField groovy.lang.Closure DELEGATE_ONLY
+staticField groovy.lang.Closure DONE
 staticField groovy.lang.Closure OWNER_FIRST
 staticField groovy.lang.Closure OWNER_ONLY
 staticField groovy.lang.Closure TO_SELF
@@ -191,13 +38,19 @@ method groovy.lang.Closure call java.lang.Object[]
 method groovy.lang.Closure curry java.lang.Object
 method groovy.lang.Closure curry java.lang.Object[]
 method groovy.lang.Closure getDelegate
+method groovy.lang.Closure getDirective
+method groovy.lang.Closure getMaximumNumberOfParameters
 method groovy.lang.Closure getResolveStrategy
 method groovy.lang.Closure ncurry int java.lang.Object
 method groovy.lang.Closure ncurry int java.lang.Object[]
 method groovy.lang.Closure setDelegate java.lang.Object
 method groovy.lang.Closure setResolveStrategy int
 method groovy.lang.GString plus java.lang.String
+staticMethod groovy.lang.ListWithDefault newInstance java.util.List boolean groovy.lang.Closure
+staticMethod groovy.lang.MapWithDefault newInstance java.util.Map groovy.lang.Closure
 method groovy.lang.Script getBinding
+staticMethod groovy.util.GroovyCollections combinations java.util.Collection
+new groovy.util.PermutationGenerator java.util.Collection
 
 # Needed for Groovy Templates to emit output:
 method java.io.PrintWriter print java.lang.Object
@@ -213,6 +66,9 @@ staticMethod java.lang.Boolean valueOf java.lang.String
 method java.lang.CharSequence charAt int
 method java.lang.CharSequence length
 method java.lang.Class getName
+method java.lang.Class getSimpleName
+method java.lang.Class isArray
+method java.lang.Class isInstance java.lang.Object
 method java.lang.Comparable compareTo java.lang.Object
 method java.lang.Enum name
 method java.lang.Enum ordinal
@@ -252,13 +108,17 @@ method java.lang.String toUpperCase
 method java.lang.String toUpperCase java.util.Locale
 method java.lang.String trim
 staticMethod java.lang.String valueOf java.lang.Object
+staticMethod java.lang.System arraycopy java.lang.Object int java.lang.Object int int
 staticMethod java.lang.System currentTimeMillis
 method java.lang.Throwable getMessage
 new java.net.MalformedURLException java.lang.String
 new java.net.URL java.lang.String
 staticMethod java.net.URLDecoder decode java.lang.String java.lang.String
 staticMethod java.net.URLEncoder encode java.lang.String java.lang.String
+new java.util.ArrayList
+new java.util.ArrayList int
 new java.util.ArrayList java.util.Collection
+staticMethod java.util.Arrays asList java.lang.Object[]
 staticMethod java.util.Arrays toString java.lang.Object[]
 staticField java.util.Calendar AM_PM
 staticField java.util.Calendar DATE
@@ -292,6 +152,8 @@ new java.util.Date long
 new java.util.HashSet
 method java.util.Iterator hasNext
 method java.util.Iterator next
+method java.util.Iterator remove
+new java.util.LinkedHashMap
 method java.util.List get int
 staticField java.util.Locale CANADA
 staticField java.util.Locale CANADA_FRENCH
@@ -353,17 +215,65 @@ method net.sf.json.JSON size
 staticMethod org.codehaus.groovy.runtime.DateGroovyMethods format java.util.Date java.lang.String
 staticMethod org.codehaus.groovy.runtime.DateGroovyMethods format java.util.Date java.lang.String java.util.TimeZone
 staticMethod org.codehaus.groovy.runtime.DateGroovyMethods getDateTimeString java.util.Date
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods any java.util.Map groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods asBoolean java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.lang.Object groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Collection java.util.Collection groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collect java.util.Map java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.lang.Object[] java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Collection java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Map java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.util.Collection java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.util.Map java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectNested java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectNested java.util.Collection java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.lang.Object[] java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.util.Collection java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.util.Map groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods disjoint java.util.Collection java.util.Collection
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Map groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachLine java.lang.CharSequence groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachLine java.lang.CharSequence int groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachLine java.lang.String groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachLine java.lang.String int groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachPermutation java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods every java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods find java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods find java.util.Map groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findIndexOf java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findIndexOf java.lang.Object int groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findIndexValues java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findIndexValues java.lang.Object java.lang.Number groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findLastIndexOf java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findLastIndexOf java.lang.Object int groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResult java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResult java.util.Collection java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResult java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResult java.util.Map java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResults java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findResults java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods flatten java.util.Collection groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.lang.Object java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.lang.String groovy.lang.IntRange
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.lang.String groovy.lang.Range
@@ -373,8 +283,21 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.util.Li
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.util.Map java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.util.regex.Matcher int
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getChars java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.util.Collection java.lang.Object[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.util.Map java.lang.Object[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupEntriesBy java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.lang.Object[] java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.Collection java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.Iterator java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.Map java.lang.Object groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods isCase java.util.Collection java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods isNumber java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods iterator java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join java.lang.Object[] java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join java.util.Collection java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods last java.lang.Object[]
@@ -382,7 +305,12 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods last java.util.Lis
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.lang.String java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Collection java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Map java.util.Map
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods max java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods max java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods min java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods min java.util.Collection groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods or java.lang.Boolean java.lang.Boolean
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods permutations java.util.List
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.lang.CharSequence java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.lang.Number java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.lang.Object[] java.lang.Iterable
@@ -400,9 +328,16 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.util.Lis
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.util.Map java.util.Collection
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.util.Map java.util.Map
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods push java.util.List java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods putAll java.util.Map java.util.Collection
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods putAt java.lang.Object java.lang.String java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods putAt java.util.List int java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods putAt java.util.Map java.lang.Object java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods removeAll java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods retainAll java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverse java.util.Iterator
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverseEach java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverseEach java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverseEach java.util.Map groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods size boolean[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods size byte[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods size char[]
@@ -417,10 +352,17 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods size short[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sort java.util.Collection groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sort java.util.Collection java.util.Comparator
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.util.Collection groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods stripIndent java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods stripIndent java.lang.String int
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods stripMargin java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods stripMargin java.lang.String java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.lang.Object[] java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.util.Collection
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.util.Collection java.lang.Object groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods tail java.util.List
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods take java.lang.CharSequence int
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toBoolean java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toInteger java.lang.String
@@ -431,6 +373,8 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList double[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList float[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList int[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.lang.Iterable
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.lang.Object[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.util.Collection
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.util.Enumeration
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList java.util.Iterator
@@ -441,8 +385,15 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods tokenize java.lang
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods tokenize java.lang.String java.lang.Character
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods tokenize java.lang.String java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods unique java.util.Collection
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods withDefault java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods withDefault java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods withLazyDefault java.util.List groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods xor java.lang.Boolean java.lang.Boolean
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarCollection java.util.Collection
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarCollection java.util.Collection int
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarMap java.util.Map
 staticMethod org.codehaus.groovy.runtime.InvokerHelper asIterator java.lang.Object
+new org.codehaus.groovy.runtime.ReverseListIterator java.util.List
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter castToType java.lang.Object java.lang.Class
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter compareEqual java.lang.Object java.lang.Object
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter compareGreaterThan java.lang.Object java.lang.Object
@@ -461,3 +412,7 @@ staticMethod org.codehaus.groovy.runtime.StringGroovyMethods find java.lang.Char
 staticMethod org.codehaus.groovy.runtime.StringGroovyMethods find java.lang.CharSequence java.lang.CharSequence groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.StringGroovyMethods find java.lang.CharSequence java.util.regex.Pattern
 staticMethod org.codehaus.groovy.runtime.StringGroovyMethods find java.lang.CharSequence java.util.regex.Pattern groovy.lang.Closure
+method org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper call java.lang.Object[]
+method org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper callForMap java.util.Map$Entry
+new org.codehaus.groovy.runtime.callsite.BooleanClosureWrapper groovy.lang.Closure
+new org.codehaus.groovy.util.ArrayIterator java.lang.Object[]

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -50,6 +50,7 @@ staticMethod java.lang.Boolean valueOf java.lang.String
 method java.lang.CharSequence charAt int
 method java.lang.CharSequence length
 method java.lang.Class getName
+method java.lang.Class getSimpleName
 method java.lang.Comparable compareTo java.lang.Object
 method java.lang.Enum name
 method java.lang.Enum ordinal

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist-groovy2
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist-groovy2
@@ -1,4 +1,14 @@
 # Groovy 2 additional overloads
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods any java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.lang.Iterable java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectEntries java.util.Iterator java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectMany java.lang.Iterable java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods collectNested java.lang.Iterable java.util.Collection groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods combinations java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods count java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.lang.Iterable groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Iterable groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Collection groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Iterator groovy.lang.Closure
@@ -6,7 +16,26 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Lis
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Map groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Set groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.SortedSet groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.Set groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods eachWithIndex java.util.SortedSet groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods every java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods every java.util.Iterator groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods find java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods findAll java.util.Set groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.lang.Iterable java.lang.Object[]
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.lang.Object[] groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods groupBy java.lang.Object[] java.lang.Object[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.List java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Set java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods max java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods min java.lang.Iterable groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods permutations java.util.List groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.lang.Iterable java.lang.Iterable
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.lang.Iterable java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.util.List java.lang.Iterable
@@ -18,5 +47,7 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.util.Set
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.util.SortedSet java.lang.Iterable
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.util.SortedSet java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.util.SortedSet java.util.Collection
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.util.List groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.util.Set groovy.lang.Closure
 
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods unique java.util.List


### PR DESCRIPTION
Might be better organized, might be things here that are problems. `invokeMethod` was needed for `sum`, so I've removed `sum` from the tests I'll be pushing up over in `workflow-cps` in an hour or so.

cc @reviewbybees 