### PR TITLE
Be explicit about classpath dir rejection reason

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -479,7 +479,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
         // - When trying to use them, the job will fail
         // - Going to the configuration page you'll have the validation error in the classpath entry
         if (entry.isClassDirectory()) {
-            LOG.log(Level.WARNING, "{0} is a class directory, which are not allowed. Ignored in configuration, use will be rejected",
+            LOG.log(Level.WARNING, "Classpath {0} is a class directory, which are not allowed. Ignored in configuration, use will be rejected",
                     entry.getURL());
             return;
         }
@@ -561,7 +561,8 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
         if (!approvedClasspathEntries.contains(new ApprovedClasspathEntry(hash, url))) {
             // Don't add it to pending if it is a class directory
             if (entry.isClassDirectory()) {
-                LOG.log(Level.WARNING, "{0} ({1}) is a class directory, which are not allowed.", new Object[] {url, hash});
+                LOG.log(Level.WARNING, "Classpath {0} ({1}) is a class directory, which are not allowed.", new Object[] {url, hash});
+                throw new UnapprovedClasspathException("classpath entry %s is a class directory, which are not allowed.", url, hash);
             } else {
                 // Never approve classpath here.
                 ApprovalContext context = ApprovalContext.create();

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/UnapprovedClasspathException.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/UnapprovedClasspathException.java
@@ -35,10 +35,14 @@ public final class UnapprovedClasspathException extends SecurityException {
     private final URL url;
     private final String hash;
 
-    UnapprovedClasspathException(URL url, String hash) {
-        super(String.format("classpath entry %s (%s) not yet approved for use", url, hash));
+    UnapprovedClasspathException(String format, URL url, String hash) {
+        super(String.format(format, url, hash));
         this.url = url;
         this.hash = hash;
+    }
+
+    UnapprovedClasspathException(URL url, String hash) {
+        this("classpath entry %s (%s) not yet approved for use", url, hash);
     }
 
     public URL getURL() {

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScriptTest.java
@@ -577,6 +577,8 @@ public class SecureGroovyScriptTest {
         {
             FreeStyleBuild b = p.scheduleBuild2(0).get();
             r.assertBuildStatus(Result.FAILURE, b);
+            r.assertLogNotContains("not yet approved", b);
+            r.assertLogContains("is a class directory, which are not allowed", b);
             assertNotEquals(testingDisplayName, b.getDisplayName());
         }
         


### PR DESCRIPTION
This is what plugin used to say before: `UnapprovedClasspathException: classpath entry file:/var/lib/jenkins/scripts/ (25b1d05c615f6e2ce3995a56287bc47e1f4597a4) not yet approved for use`. Confused me for hours as there was no approval request generated contrary what the message implies.