### PR TITLE
Bump version of groovy-sandbox to support workflow-cps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>groovy-sandbox</artifactId>
-      <version>1.10</version>
+      <version>1.11</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
I've been chasing an issue I have with using two classes in a shared groovy library where one inherits from the other.  At one point I was getting the following exception from groovy-cps:
```
java.lang.NoSuchMethodError: org.kohsuke.groovy.sandbox.impl.Checker.checkedSuperCall(Ljava/lang/Class;Ljava/lang/Object;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/Object;
java.lang.NoSuchMethodError: org.kohsuke.groovy.sandbox.impl.Checker.checkedSuperCall(Ljava/lang/Class;Ljava/lang/Object;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/Object;
	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.superCall(SandboxInvoker.java:24)
```

After some additional work I finally deciphered cause of this to be a mismatched dependency between groovy-cps (part of the workflow-cps plugin) and script-security-plugin.  Both plugins/libraries depend on groovy-sandbox, but while groovy-cps was compiled against groovy-sandbox-1.11 (it's an optional dependency apparently), script-security-plugin bundles groovy-sandbox-1.10.  The relevant function (`Checker.checkedSuperCall()`) was only added in groovy-sandbox-1.11.  I was able to fix the issue by deleting `groovy-sandbox-1.10.jar` from the `plugins/script-security-plugin` folder and put `groovy-sandbox-1.11.jar` in there instead.

It may be a better solution to set up a separate project (similar to github-api) to contain groovy-sandbox, but this is the simple solution that I know how to do.

I don't know if this is related to JENKINS-42563 or not, there's a couple similar lines in the stack trace and I couldn't get `super.parentFunction()` to work, only `parentFunction()` (`super.parentFunction()` appears to involve a constructor somehow?).  On the other hand, that example has closures in it which I understand to have other issues too.