### PR TITLE
Update jenkins-whitelist to allow timeout cause detection

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/jenkins-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/jenkins-whitelist
@@ -31,3 +31,5 @@ field hudson.scm.EditType EDIT
 method hudson.scm.EditType getName
 method hudson.tools.ToolInstallation getHome
 method hudson.tools.ToolInstallation getName
+method org.jenkinsci.plugins.workflow.steps.FlowInterruptedException getCauses
+method org.jenkinsci.plugins.workflow.support.steps.input.Rejection getUser


### PR DESCRIPTION
@jglick

Per this example: [Pipeline: How to add an input step, with timeout, that continues if timeout is reached, using a default value](https://support.cloudbees.com/hc/en-us/articles/226554067-Pipeline-How-to-add-an-input-step-with-timeout-that-continues-if-timeout-is-reached-using-a-default-value), the only way to distinguish a timeout from an input dialog abort, from a system abort is by examining the causes, but doing so causes whitelist violations.

Ideally both the timeout and the input dialog abort would raise different subclassed exceptions, but while they're raising the FlowInterruptedException there doesn't seem to be another way than examining the causes, and so, IMHO, the methods needed to do so should be whitelisted.
