### PR TITLE
Add groovy-sandbox.version POM property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Plugin</url> 
     <properties>
       <jenkins.version>2.7.3</jenkins.version>
+      <groovy-sandbox.version>1.12</groovy-sandbox.version>
     </properties>
     <licenses>
         <license>
@@ -47,7 +48,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>groovy-sandbox</artifactId>
-      <version>1.12</version>
+      <version>${groovy-sandbox.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
I'm working on tooling to do testing of core + groovy-sandbox +
groovy-cps + workflow-cps + script-security + the rest of the main
Pipeline plugins against bleeding-edge versions of each other and
different versions of Groovy. To do this, it'd be a lot easier if the
dependencies between the various things I'm building/testing had their
versions controlled by properties.

cc @reviewbybees