### PR TITLE
Allow string join

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -320,8 +320,18 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods inject java.util.M
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods isCase java.util.Collection java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods isNumber java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods iterator java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join boolean[] java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join byte[] java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join char[] java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join double[] java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join float[] java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join int[] java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join java.lang.Iterable java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join java.lang.Object[] java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join java.util.Collection java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join java.util.Iterator java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join long[] java.lang.String
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods join short[] java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods last java.lang.Object[]
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods last java.util.List
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.lang.String java.lang.Object

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
@@ -30,10 +30,18 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.SortedSet;
 import java.util.TreeSet;
+
+import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
+import org.junit.Assert;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -62,7 +70,32 @@ public class StaticWhitelistTest {
         } finally {
             is.close();
         }
-        assertEquals("entries in " + definition + " should be sorted and unique", new TreeSet<EnumeratingWhitelist.Signature>(sigs).toString(), sigs.toString());
+
+        HashSet<EnumeratingWhitelist.Signature> existingSigs = new HashSet<EnumeratingWhitelist.Signature>(sigs.size());
+        boolean hasDupes = false;
+        for (EnumeratingWhitelist.Signature sig : sigs) {
+            if (!existingSigs.add(sig)) {
+                System.out.println("Duplicate whitelist signature: "+sig);
+                hasDupes = true;
+            }
+        }
+        Assert.assertFalse("Whitelist contains duplicate entries, and this is not allowed!  Please see list above.", hasDupes);
+
+        ArrayList<EnumeratingWhitelist.Signature> sorted = new ArrayList<EnumeratingWhitelist.Signature>(sigs);
+        Collections.sort(sorted);
+
+        boolean isUnsorted = false;
+        for (int i=0; i<sigs.size(); i++) {
+            EnumeratingWhitelist.Signature expectedSig = sorted.get(i);
+            EnumeratingWhitelist.Signature actualSig = sigs.get(i);
+            if (!expectedSig.equals(actualSig)) {
+                System.out.println(MessageFormat.format("Signatures out of order, at index {0} found {1} but expected {2}", i, actualSig, expectedSig));
+                isUnsorted = true;
+            }
+        }
+        Assert.assertFalse("Whitelist is out of order!  Please see issues above.", isUnsorted);
+
+
         for (EnumeratingWhitelist.Signature sig : sigs) {
             try {
                 assertTrue(sig + " does not exist (or is an override)", sig.exists());


### PR DESCRIPTION
Also make the test better show out of order issues with the whitelist.  This allows the easiest way to make a string from an array or collection in Groovy. 

@reviewbybees