### PR TITLE
[FIXED JENKINS-46391] Fix ~/foo/ and whitelist other Pattern stuff

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -188,6 +188,8 @@ method java.util.regex.MatchResult group int
 method java.util.regex.Matcher matches
 method java.util.regex.Matcher replaceAll java.lang.String
 method java.util.regex.Matcher replaceFirst java.lang.String
+staticMethod java.util.regex.Pattern compile java.lang.String
+method java.util.regex.Pattern matcher java.lang.CharSequence
 method net.sf.json.JSON isArray
 method net.sf.json.JSON size
 
@@ -459,6 +461,7 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimil
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarCollection java.util.Collection int
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport createSimilarMap java.util.Map
 staticMethod org.codehaus.groovy.runtime.InvokerHelper asIterator java.lang.Object
+staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter bitwiseNegate java.lang.Object
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter castToType java.lang.Object java.lang.Class
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter compareEqual java.lang.Object java.lang.Object
 staticMethod org.codehaus.groovy.runtime.ScriptBytecodeAdapter compareGreaterThan java.lang.Object java.lang.Object

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.groovy.control.CompilerConfiguration;
@@ -865,4 +866,15 @@ public class SandboxInterceptorTest {
         assertEvaluate(new GenericWhitelist(), "abc", "String a; a = 'abc'; return a");
     }
 
+    @Issue("JENKINS-46391")
+    @Test
+    public void newPattern() throws Exception {
+        assertEvaluate(new GenericWhitelist(), true, "def f = java.util.regex.Pattern.compile('f.*'); return f.matcher('foo').matches()");
+    }
+
+    @Issue("JENKINS-46391")
+    @Test
+    public void tildePattern() throws Exception {
+        assertEvaluate(new GenericWhitelist(), Pattern.class, "def f = ~/f.*/; return f.class");
+    }
 }


### PR DESCRIPTION
[JENKINS-46391](https://issues.jenkins-ci.org/browse/JENKINS-46391)

CPS code ends up calling `~/foo/` as `ScriptBytecodeAdapter.bitwiseNegate(Object)`, so we need to whitelist that. Through whacky Groovy magic, that'll end up resulting in a call behind the scenes to `StringGroovyMethods.bitwiseNegate(CharSequence)`, which returns... a `Pattern`. Because of course it does. So tada.

Also whitelisted `Pattern.compile(String)` and `Pattern#matcher(CharSequence)` since they seem worth whitelisting while we're doing `Pattern`-related stuff.

cc @reviewbybees