### PR TITLE
[FIXED JENKINS-46764] Trim leading/trailing ws from signatures

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
@@ -95,7 +95,7 @@ public final class StaticWhitelist extends EnumeratingWhitelist {
     }
 
     static Signature parse(String line) throws IOException {
-        String[] toks = line.split(" ");
+        String[] toks = line.trim().split(" ");
         if (toks[0].equals("method")) {
             if (toks.length < 3) {
                 throw new IOException(line);
@@ -127,7 +127,7 @@ public final class StaticWhitelist extends EnumeratingWhitelist {
     }
 
     private void add(String line) throws IOException {
-        Signature s = parse(line);
+        Signature s = parse(line.trim());
         if (s instanceof StaticMethodSignature) {
             staticMethodSignatures.add((StaticMethodSignature) s);
         } else if (s instanceof MethodSignature) {

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -884,4 +884,11 @@ public class SandboxInterceptorTest {
     public void tildePattern() throws Exception {
         assertEvaluate(new GenericWhitelist(), Pattern.class, "def f = ~/f.*/; return f.class");
     }
+
+    @Issue("JENKINS-46764")
+    @Test
+    public void whitespaceAtStartOfSignature() throws Exception {
+        assertEvaluate(new StaticWhitelist("method java.lang.Object toString", " new java.lang.Exception java.lang.String"), "X1: x", "class X1 extends Exception {X1(String x) {super(x)}}; new X1('x').toString()");
+
+    }
 }


### PR DESCRIPTION
[JENKINS-46764](https://issues.jenkins-ci.org/browse/JENKINS-46764)

If a signature string starts with whitespace currently, that results
in rejecting all signatures that are approved in that StaticWhitelist,
due to the IOException thrown when parsing. So let's trim away said
whitespace, and also ensure that adding a signature trims it as well.

Perhaps a more comprehensive solution is needed for not barfing out
everything on one failed-to-parse signature, though.

cc @reviewbybees