### PR TITLE
Remove check for param type in parametersForVarargs if parameters array length == 1

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
@@ -96,7 +96,7 @@ class GroovyCallSiteSelector {
         assert componentType != null;
         int arrayLength = parameters.length - fixedLen;
         if (arrayLength >= 0) {
-            if (arrayLength == 1 && parameterTypes[fixedLen].isInstance(parameters[fixedLen])) {
+            if (arrayLength == 1) {
                 // not a varargs call
                 return parameters;
             } else {


### PR DESCRIPTION
As described in [JENKINS-47159](https://issues.jenkins-ci.org/browse/JENKINS-47159) this causes a valid call to new ParametersAction(ParameterValue[]) to fail with 
```
org.codehaus.groovy.runtime.typehandling.GroovyCastException
: Cannot cast object '[(StringParameterValue) GIT_PUSH_USER='builder', (StringParameterValue) SHA1='9df4d51934c3f39663c5dbc1e08c09775b45c61f' (BooleanParameterValue) TEST_ONLY_CHANGED='false']' with class 'java.util.ArrayList' to class 'hudson.model.ParameterValue' due to: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: hudson.model.ParameterValue(hudson.model.StringParameterValue, hudson.model.StringParameterValue,hudson.model.BooleanParameterValue)
```
If I understand this logic correctly - if there's only one parameter passed - there's no need to try and cast it to an array, we can just safely return it as is. 
