### PR TITLE
[JENKINS-47159] Catch GroovyCastException to enable finding the correct constructor when

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
@@ -100,11 +100,17 @@ class GroovyCallSiteSelector {
                 // not a varargs call
                 return parameters;
             } else {
-                Object array = DefaultTypeTransformation.castToVargsArray(parameters, 0, parameterTypes[fixedLen]);
-                Object[] parameters2 = new Object[fixedLen + 1];
-                System.arraycopy(parameters, 0, parameters2, 0, fixedLen);
-                parameters2[fixedLen] = array;
-                return parameters2;
+                try { //if casting  is unsuccessful - just return as is
+                    Object array = DefaultTypeTransformation.castToVargsArray(parameters, 0, parameterTypes[fixedLen]);
+                    Object[] parameters2 = new Object[fixedLen + 1];
+                    System.arraycopy(parameters, 0, parameters2, 0, fixedLen);
+                    parameters2[fixedLen] = array;
+                    return parameters2;
+                }
+                catch(org.codehaus.groovy.runtime.typehandling.GroovyCastException e)
+                {
+                    return parameters;
+                }
             }
         } else {
             return parameters;

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
@@ -32,6 +32,8 @@ import hudson.EnvVars;
 import hudson.model.Hudson;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 import jenkins.model.Jenkins;
 import org.codehaus.groovy.runtime.GStringImpl;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.EnumeratingWhitelistTest;
@@ -92,6 +94,10 @@ public class GroovyCallSiteSelectorTest {
     @Issue("JENKINS-45117")
     @Test public void constructorVarargs() throws Exception {
         assertEquals(EnvVars.class.getConstructor(), GroovyCallSiteSelector.constructor(EnvVars.class, new Object[0]));
+        Map<String, String> myMap = new HashMap<String, String>();
+        myMap.put("ONE", "one");
+        myMap.put("TWO", "two"); 
+        assertEquals(EnvVars.class.getConstructor(Map.class), GroovyCallSiteSelector.constructor(EnvVars.class, new Object[] {myMap}));
         assertEquals(EnvVars.class.getConstructor(String[].class), GroovyCallSiteSelector.constructor(EnvVars.class, new Object[] {"x"}));
     }
 


### PR DESCRIPTION
varargs is involved.

Otherwise we're hitting [JENKINS-47159](https://issues.jenkins-ci.org/browse/JENKINS-47159)

This allows skipping the exception in trying to cast list to varargs and allows to find the correct constructor.

