### PR TITLE
[FIXED JENKINS-47159] Set proper vargs location

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
@@ -99,17 +99,14 @@ class GroovyCallSiteSelector {
             if (arrayLength == 1 && parameterTypes[fixedLen].isInstance(parameters[fixedLen])) {
                 // not a varargs call
                 return parameters;
-            } else {
-                int firstVargsPos = fixedLen;
-                // Special-casing to handle single-parameter cases, which are still varargs.
-                if (parameters.length == 1) {
-                    firstVargsPos = arrayLength;
-                }
-                Object array = DefaultTypeTransformation.castToVargsArray(parameters, firstVargsPos, parameterTypes[fixedLen]);
+            } else if (parameters.length > fixedLen && componentType.isInstance(parameters[fixedLen])) {
+                Object array = DefaultTypeTransformation.castToVargsArray(parameters, fixedLen, parameterTypes[fixedLen]);
                 Object[] parameters2 = new Object[fixedLen + 1];
                 System.arraycopy(parameters, 0, parameters2, 0, fixedLen);
                 parameters2[fixedLen] = array;
                 return parameters2;
+            } else {
+                return parameters;
             }
         } else {
             return parameters;

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
@@ -93,24 +93,26 @@ class GroovyCallSiteSelector {
         int fixedLen = parameterTypes.length - 1;
         Class<?> componentType = parameterTypes[fixedLen].getComponentType();
         assert componentType != null;
+        if (componentType.isPrimitive()) {
+            componentType = ClassUtils.primitiveToWrapper(componentType);
+        }
         int arrayLength = parameters.length - fixedLen;
 
         if (arrayLength >= 0) {
             if (arrayLength == 1 && parameterTypes[fixedLen].isInstance(parameters[fixedLen])) {
                 // not a varargs call
                 return parameters;
-            } else if (parameters.length > fixedLen && componentType.isInstance(parameters[fixedLen])) {
+            } else if ((arrayLength > 0 && componentType.isInstance(parameters[fixedLen])) ||
+                    arrayLength == 0) {
                 Object array = DefaultTypeTransformation.castToVargsArray(parameters, fixedLen, parameterTypes[fixedLen]);
                 Object[] parameters2 = new Object[fixedLen + 1];
                 System.arraycopy(parameters, 0, parameters2, 0, fixedLen);
                 parameters2[fixedLen] = array;
+
                 return parameters2;
-            } else {
-                return parameters;
             }
-        } else {
-            return parameters;
         }
+        return parameters;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
@@ -100,7 +100,12 @@ class GroovyCallSiteSelector {
                 // not a varargs call
                 return parameters;
             } else {
-                Object array = DefaultTypeTransformation.castToVargsArray(parameters, arrayLength, parameterTypes[fixedLen]);
+                int firstVargsPos = fixedLen;
+                // Special-casing to handle single-parameter cases, which are still varargs.
+                if (parameters.length == 1) {
+                    firstVargsPos = arrayLength;
+                }
+                Object array = DefaultTypeTransformation.castToVargsArray(parameters, firstVargsPos, parameterTypes[fixedLen]);
                 Object[] parameters2 = new Object[fixedLen + 1];
                 System.arraycopy(parameters, 0, parameters2, 0, fixedLen);
                 parameters2[fixedLen] = array;

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
@@ -27,7 +27,6 @@ package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
 import com.google.common.primitives.Primitives;
 import groovy.lang.GString;
 import java.lang.reflect.AccessibleObject;
-import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -95,12 +94,13 @@ class GroovyCallSiteSelector {
         Class<?> componentType = parameterTypes[fixedLen].getComponentType();
         assert componentType != null;
         int arrayLength = parameters.length - fixedLen;
+
         if (arrayLength >= 0) {
             if (arrayLength == 1 && parameterTypes[fixedLen].isInstance(parameters[fixedLen])) {
                 // not a varargs call
                 return parameters;
             } else {
-                Object array = DefaultTypeTransformation.castToVargsArray(parameters, 0, parameterTypes[fixedLen]);
+                Object array = DefaultTypeTransformation.castToVargsArray(parameters, arrayLength, parameterTypes[fixedLen]);
                 Object[] parameters2 = new Object[fixedLen + 1];
                 System.arraycopy(parameters, 0, parameters2, 0, fixedLen);
                 parameters2[fixedLen] = array;

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
@@ -102,10 +102,6 @@ public class GroovyCallSiteSelectorTest {
     @Test public void constructorVarargs() throws Exception {
         assertEquals(EnvVars.class.getConstructor(), GroovyCallSiteSelector.constructor(EnvVars.class, new Object[0]));
         assertEquals(EnvVars.class.getConstructor(String[].class), GroovyCallSiteSelector.constructor(EnvVars.class, new Object[] {"x"}));
-        Map<String, String> myMap = new HashMap<>();
-        myMap.put("ONE", "one");
-        myMap.put("TWO", "two");
-        assertEquals(EnvVars.class.getConstructor(Map.class), GroovyCallSiteSelector.constructor(EnvVars.class, new Object[] {myMap}));
         List<ParameterValue> params = new ArrayList<>();
         params.add(new StringParameterValue("someParam", "someValue"));
         params.add(new BooleanParameterValue("someBool", true));

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
@@ -116,4 +116,18 @@ public class GroovyCallSiteSelectorTest {
                         new Object[]{String.class, "foo", Integer.class, Float.class}));
     }
 
+    @Issue("JENKINS-47159")
+    @Test
+    public void varargsFailureCases() throws Exception {
+        // If there's a partial match, we should get a ClassCastException
+        try {
+            assertNull(GroovyCallSiteSelector.constructor(EnvVars.class, new Object[]{"x", String.class}));
+        } catch (Exception e) {
+            assertTrue(e instanceof ClassCastException);
+            assertEquals("java.lang.Class cannot be cast to java.lang.String", e.getMessage());
+        }
+        // If it's a complete non-match, we just shouldn't get a constructor.
+        assertNull(GroovyCallSiteSelector.constructor(ParametersAction.class, new Object[]{"a", "b"}));
+    }
+
 }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
@@ -121,10 +121,12 @@ public class GroovyCallSiteSelectorTest {
     public void varargsFailureCases() throws Exception {
         // If there's a partial match, we should get a ClassCastException
         try {
-            assertNull(GroovyCallSiteSelector.constructor(EnvVars.class, new Object[]{"x", String.class}));
+            assertNull(GroovyCallSiteSelector.constructor(ParametersAction.class,
+                    new Object[]{new BooleanParameterValue("someBool", true), "x"}));
         } catch (Exception e) {
             assertTrue(e instanceof ClassCastException);
-            assertEquals("java.lang.Class cannot be cast to java.lang.String", e.getMessage());
+            assertEquals("Cannot cast object 'x' with class 'java.lang.String' to class 'hudson.model.ParameterValue'",
+                    e.getMessage());
         }
         // If it's a complete non-match, we just shouldn't get a constructor.
         assertNull(GroovyCallSiteSelector.constructor(ParametersAction.class, new Object[]{"a", "b"}));

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
@@ -34,6 +34,7 @@ import hudson.model.Hudson;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import hudson.model.ParameterValue;
@@ -132,4 +133,11 @@ public class GroovyCallSiteSelectorTest {
         assertNull(GroovyCallSiteSelector.constructor(ParametersAction.class, new Object[]{"a", "b"}));
     }
 
+    @Issue("JENKINS-37257")
+    @Test
+    public void varargsArrayElementTypeMismatch() throws Exception {
+        List<String> l = Arrays.asList("a", "b", "c");
+        assertEquals(String.class.getMethod("join", CharSequence.class, Iterable.class),
+                GroovyCallSiteSelector.staticMethod(String.class, "join", new Object[]{",", l}));
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
@@ -34,15 +34,14 @@ import hudson.model.Hudson;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.StringParameterValue;
 import jenkins.model.Jenkins;
 import org.codehaus.groovy.runtime.GStringImpl;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.EnumeratingWhitelist;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.EnumeratingWhitelistTest;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
 import static org.junit.Assert.*;
@@ -101,7 +100,7 @@ public class GroovyCallSiteSelectorTest {
     @Issue("JENKINS-45117")
     @Test public void constructorVarargs() throws Exception {
         assertEquals(EnvVars.class.getConstructor(), GroovyCallSiteSelector.constructor(EnvVars.class, new Object[0]));
-        assertEquals(EnvVars.class.getConstructor(String[].class), GroovyCallSiteSelector.constructor(EnvVars.class, new Object[] {"x"}));
+        assertEquals(EnvVars.class.getConstructor(String[].class), GroovyCallSiteSelector.constructor(EnvVars.class, new Object[]{"x"}));
         List<ParameterValue> params = new ArrayList<>();
         params.add(new StringParameterValue("someParam", "someValue"));
         params.add(new BooleanParameterValue("someBool", true));
@@ -109,7 +108,12 @@ public class GroovyCallSiteSelectorTest {
         assertEquals(ParametersAction.class.getConstructor(List.class),
                 GroovyCallSiteSelector.constructor(ParametersAction.class, new Object[]{params}));
         assertEquals(ParametersAction.class.getConstructor(ParameterValue[].class),
+                GroovyCallSiteSelector.constructor(ParametersAction.class, new Object[]{params.get(0)}));
+        assertEquals(ParametersAction.class.getConstructor(ParameterValue[].class),
                 GroovyCallSiteSelector.constructor(ParametersAction.class, params.toArray()));
+        assertEquals(EnumeratingWhitelist.MethodSignature.class.getConstructor(Class.class, String.class, Class[].class),
+                GroovyCallSiteSelector.constructor(EnumeratingWhitelist.MethodSignature.class,
+                        new Object[]{String.class, "foo", Integer.class, Float.class}));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
@@ -29,9 +29,18 @@ import groovy.lang.Binding;
 import groovy.lang.GString;
 import groovy.lang.Script;
 import hudson.EnvVars;
+import hudson.model.BooleanParameterValue;
 import hudson.model.Hudson;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.StringParameterValue;
 import jenkins.model.Jenkins;
 import org.codehaus.groovy.runtime.GStringImpl;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.EnumeratingWhitelistTest;
@@ -93,6 +102,18 @@ public class GroovyCallSiteSelectorTest {
     @Test public void constructorVarargs() throws Exception {
         assertEquals(EnvVars.class.getConstructor(), GroovyCallSiteSelector.constructor(EnvVars.class, new Object[0]));
         assertEquals(EnvVars.class.getConstructor(String[].class), GroovyCallSiteSelector.constructor(EnvVars.class, new Object[] {"x"}));
+        Map<String, String> myMap = new HashMap<>();
+        myMap.put("ONE", "one");
+        myMap.put("TWO", "two");
+        assertEquals(EnvVars.class.getConstructor(Map.class), GroovyCallSiteSelector.constructor(EnvVars.class, new Object[] {myMap}));
+        List<ParameterValue> params = new ArrayList<>();
+        params.add(new StringParameterValue("someParam", "someValue"));
+        params.add(new BooleanParameterValue("someBool", true));
+        params.add(new StringParameterValue("someOtherParam", "someOtherValue"));
+        assertEquals(ParametersAction.class.getConstructor(List.class),
+                GroovyCallSiteSelector.constructor(ParametersAction.class, new Object[]{params}));
+        assertEquals(ParametersAction.class.getConstructor(ParameterValue[].class),
+                GroovyCallSiteSelector.constructor(ParametersAction.class, params.toArray()));
     }
 
 }


### PR DESCRIPTION
[JENKINS-47159](https://issues.jenkins-ci.org/browse/JENKINS-47159)

Replaces #155 

We shouldn't be starting looking for vargs until we've got to the
index of the last parameter type *and* that last parameter type is an
array. So...tada.

cc @reviewbybees @antweiss