### PR TITLE
[FIXED JENKINS-47893] Properly set index for varargs casting

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
@@ -100,7 +100,7 @@ class GroovyCallSiteSelector {
                 // not a varargs call
                 return parameters;
             } else {
-                Object array = DefaultTypeTransformation.castToVargsArray(parameters, 0, parameterTypes[fixedLen]);
+                Object array = DefaultTypeTransformation.castToVargsArray(parameters, fixedLen, parameterTypes[fixedLen]);
                 Object[] parameters2 = new Object[fixedLen + 1];
                 System.arraycopy(parameters, 0, parameters2, 0, fixedLen);
                 parameters2[fixedLen] = array;


### PR DESCRIPTION
[JENKINS-47893](https://issues.jenkins-ci.org/browse/JENKINS-47893)

https://github.com/jenkinsci/script-security-plugin/commit/8abef0d66fa78f4c187789d8fb76680b91ff0e97 fixed GString varargs logic...sort of. For some reason, I put a 0 in for the start index for the array in the parameters, which was wrong. Duh. This fixes that by properly using the right index.

cc @reviewbybees