### PR TITLE
Removing test dependency on GroovyPostbuildRecorder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,23 +55,5 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency> <!-- For memory leak testing. -->
-      <groupId>org.jvnet.hudson.plugins</groupId>
-      <artifactId>groovy-postbuild</artifactId>
-      <version>2.3.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency> <!-- Required for groovy postbuild. -->
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>matrix-project</artifactId>
-      <version>1.4.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency> <!-- Required for groovy postbuild, because needed for matrix-project after unbundling. -->
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>junit</artifactId>
-      <version>1.15</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyMemoryLeakTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyMemoryLeakTest.java
@@ -7,7 +7,6 @@ import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
@@ -46,10 +45,8 @@ public class GroovyMemoryLeakTest {
     @Test
     public void loaderReleased() throws Exception {
         FreeStyleProject p = r.jenkins.createProject(FreeStyleProject.class, "p");
-        p.addPublisher(new GroovyPostbuildRecorder(
-                new SecureGroovyScript(GroovyMemoryLeakTest.class.getName()+".register(this)", false, null),
-                2, false
-        ));
+        p.getPublishersList().add(new TestGroovyRecorder(
+                new SecureGroovyScript(GroovyMemoryLeakTest.class.getName()+".register(this)", false, null)));
         r.buildAndAssertSuccess(p);
 
         assertFalse(LOADERS.isEmpty());

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/TestGroovyRecorder.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/TestGroovyRecorder.java
@@ -59,7 +59,7 @@ public final class TestGroovyRecorder extends Recorder {
         try {
             Binding binding = new Binding();
             binding.setVariable("build", build);
-            build.setDescription(script.evaluate(Jenkins.getInstance().getPluginManager().uberClassLoader, binding).toString());
+            build.setDescription(String.valueOf(script.evaluate(Jenkins.getInstance().getPluginManager().uberClassLoader, binding)));
         } catch (Exception x) {
             throw new IOException(x);
         }


### PR DESCRIPTION
Simplification of #161. Yes I checked that the test still fails if

```java
canDoCleanup = true;
```

is commented out.

@reviewbybees