### PR TITLE
Hide link to /scriptApproval when there is nothing approved or pending

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.37</version>
+    <version>3.0</version>
     <relativePath />
   </parent>
 
@@ -12,7 +12,7 @@
     <packaging>hpi</packaging>
     <name>Script Security Plugin</name>
     <description>Allows Jenkins administrators to control what in-process scripts can be run by less-privileged users.</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Plugin</url> 
+    <url>https://wiki.jenkins.io/display/JENKINS/Script+Security+Plugin</url>
     <properties>
       <jenkins.version>2.7.3</jenkins.version>
     </properties>

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -354,6 +354,17 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
         }
     }
 
+    /** Nothing has ever been approved or is pending. */
+    boolean isEmpty() {
+        return approvedScriptHashes.isEmpty() &&
+               approvedSignatures.isEmpty() &&
+               aclApprovedSignatures.isEmpty() &&
+               approvedClasspathEntries.isEmpty() &&
+               pendingScripts.isEmpty() &&
+               pendingSignatures.isEmpty() &&
+               pendingClasspathEntries.isEmpty();
+    }
+
     private static String hash(String script, String language) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-1");

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalLink.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalLink.java
@@ -35,6 +35,9 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Extension public final class ScriptApprovalLink extends ManagementLink {
 
     @Override public String getIconFileName() {
+        if (ScriptApproval.get().isEmpty()) {
+            return null;
+        }
         return "notepad.png";
     }
 

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
@@ -76,6 +76,10 @@ public class ScriptApprovalTest extends AbstractApprovalTest<ScriptApprovalTest.
         assertThat(dangerousTextArea.getTextContent(), Matchers.containsString(DANGEROUS_SIGNATURE));
     }
 
+    @Test public void nothingHappening() throws Exception {
+        assertThat(r.createWebClient().goTo("manage").getByXPath("//a[@href='scriptApproval']"), Matchers.empty());
+    }
+
     private Script script(String groovy) {
         return new Script(groovy);
     }


### PR DESCRIPTION
Makes this plugin behave like more of a pure library when it is not in active use: there is no particular reason to even see this management link if all attempted uses of script security (if any) have been successful uses of default whitelist entries in the sandbox.

@reviewbybees