### PR TITLE
Set java.level to 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <url>https://wiki.jenkins.io/display/JENKINS/Script+Security+Plugin</url>
     <properties>
       <jenkins.version>2.7.3</jenkins.version>
+      <java.level>7</java.level>
     </properties>
     <licenses>
         <license>


### PR DESCRIPTION
plugin POM 3.0 defaults `java.level` to 8, which is not the right value when we're still building against core 2.7.3. So let's set the level to 7.

cc @reviewbybees