### PR TITLE
Blacklist System.setProperty

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/blacklist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/blacklist
@@ -68,6 +68,9 @@ staticMethod java.lang.System getProperty java.lang.String java.lang.String
 staticMethod java.lang.System getenv
 staticMethod java.lang.System getenv java.lang.String
 
+# Maybe could bypass other protections.
+staticMethod java.lang.System setProperty java.lang.String java.lang.String
+
 # Could be used to read local files.
 method java.net.URL getContent
 method java.net.URL getContent java.lang.Class[]


### PR DESCRIPTION
Noticed this whitelisted in someone’s `scriptApproval.xml`. No idea why, but cannot be a good idea.

@reviewbybees