### PR TITLE
[FIXED JENKINS-48501] Null-safety in varargs->array check

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
@@ -193,15 +193,17 @@ class GroovyCallSiteSelector {
         return findMatchingMethod(receiver, method, args);
     }
 
-    private static Method findMatchingMethod(Class<?> receiver, String method, Object[] args) {
+    private static Method findMatchingMethod(@Nonnull Class<?> receiver, @Nonnull String method, @Nonnull Object[] args) {
         Method candidate = null;
 
         for (Method m : receiver.getDeclaredMethods()) {
-            boolean isVarArgs = isVarArgsMethod(m, args);
-            if (m.getName().equals(method) && (matches(m.getParameterTypes(), args, isVarArgs))) {
-                if (candidate == null || isMoreSpecific(m, m.getParameterTypes(), isVarArgs, candidate,
-                        candidate.getParameterTypes(), isVarArgsMethod(candidate, args))) {
-                    candidate = m;
+            if (m != null) {
+                boolean isVarArgs = isVarArgsMethod(m, args);
+                if (m.getName().equals(method) && (matches(m.getParameterTypes(), args, isVarArgs))) {
+                    if (candidate == null || isMoreSpecific(m, m.getParameterTypes(), isVarArgs, candidate,
+                            candidate.getParameterTypes(), isVarArgsMethod(candidate, args))) {
+                        candidate = m;
+                    }
                 }
             }
         }
@@ -211,7 +213,7 @@ class GroovyCallSiteSelector {
     /**
      * Emulates, with some tweaks, {@link org.codehaus.groovy.reflection.ParameterTypes#isVargsMethod(Object[])}
      */
-    private static boolean isVarArgsMethod(Method m, Object[] args) {
+    private static boolean isVarArgsMethod(@Nonnull Method m, @Nonnull Object[] args) {
         if (m.isVarArgs()) {
             return true;
         }
@@ -226,9 +228,9 @@ class GroovyCallSiteSelector {
         // If there are more arguments than parameter types and the last parameter type is an array, we may be vargy.
         if (paramTypes[lastIndex].isArray() && args.length > paramTypes.length) {
             Class<?> lastClass = paramTypes[lastIndex].getComponentType();
-            // Check each possible vararg to see if it can be cast to the array's component type. If not, we're not vargy.
+            // Check each possible vararg to see if it can be cast to the array's component type or is null. If not, we're not vargy.
             for (int i = lastIndex; i < args.length; i++) {
-                if (!lastClass.isAssignableFrom(args[i].getClass())) {
+                if (args[i] != null && !lastClass.isAssignableFrom(args[i].getClass())) {
                     return false;
                 }
             }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -1011,4 +1011,15 @@ public class SandboxInterceptorTest {
         assertRejected(new GenericWhitelist(), "new java.io.File java.lang.String",
                 "def s = []; ('/tmp/foo' as File).each { s << it }\n");
     }
+
+    @Issue("JENKINS-48501")
+    @Test
+    public void nullInVarArgsAsArray() throws Exception {
+        String script = "def TEST_FMT = 'a:%s b:%s c:%s d:%s'\n" +
+                "String s = sprintf(TEST_FMT, null, '2', '3', '4')\n" +
+                "return s\n";
+        assertEvaluate(new StaticWhitelist("staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sprintf java.lang.Object java.lang.String java.lang.Object[]"),
+                "a:null b:2 c:3 d:4",
+                script);
+    }
 }


### PR DESCRIPTION
[JENKINS-48501](https://issues.jenkins-ci.org/browse/JENKINS-48501)

Added some more null checks in the vicinity just to be safe, but the
main thing here is that we needed to avoid an NPE *and* treat a null
arg as if it were of the target method's trailing array parameter's
component type, since, well, null is every type.

Downstream test of the specific issue that uncovered this (variable declaration with a specified type in a CPS script without a right-hand side) coming momentarily.

cc @reviewbybees @rsandell 