### PR TITLE
add DefaultGroovyMethods contains java.lang.Iterable java.lang.Object to whitelist

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -245,6 +245,7 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods contains char[] ja
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods contains double[] java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods contains float[] java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods contains int[] java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods contains java.lang.Iterable java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods contains long[] java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods contains short[] java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods containsAll Collection[] java.lang.Object
@@ -364,11 +365,11 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.Li
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods next java.lang.Number
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods or java.lang.Boolean java.lang.Boolean
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods padLeft java.lang.CharSequence java.lang.Number
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods padLeft java.lang.CharSequence java.lang.Number java.lang.CharSequence 
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods padLeft java.lang.CharSequence java.lang.Number java.lang.CharSequence
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods padLeft java.lang.String java.lang.Number
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods padLeft java.lang.String java.lang.Number java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods padRight java.lang.CharSequence java.lang.Number
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods padRight java.lang.CharSequence java.lang.Number java.lang.CharSequence 
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods padRight java.lang.CharSequence java.lang.Number java.lang.CharSequence
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods padRight java.lang.String java.lang.Number
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods padRight java.lang.String java.lang.Number java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods permutations java.util.List


### PR DESCRIPTION
CC @svanoort since I saw you were the most recent person to merge/approve an update to the whitelist.