### PR TITLE
[SECURITY-683] Preventively reduce Spectre/Meltdown risk

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/blacklist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/blacklist
@@ -68,6 +68,9 @@ staticMethod java.lang.System getProperty java.lang.String java.lang.String
 staticMethod java.lang.System getenv
 staticMethod java.lang.System getenv java.lang.String
 
+# SECURITY-683 speculative approach to Spectre/Meltdown
+staticMethod java.lang.System nanoTime
+
 # Maybe could bypass other protections.
 staticMethod java.lang.System setProperty java.lang.String java.lang.String
 
@@ -103,6 +106,3 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods putAt java.lang.Ob
 
 # TODO do we need a @Blacklisted annotation?
 method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild
-
-# SECURITY-683 speculative approach to Spectre/Meltdown
-staticMethod java.lang.System nanoTime

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/blacklist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/blacklist
@@ -103,3 +103,6 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods putAt java.lang.Ob
 
 # TODO do we need a @Blacklisted annotation?
 method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild
+
+# SECURITY-683 speculative approach to Spectre/Meltdown
+staticMethod java.lang.System nanoTime


### PR DESCRIPTION
- preventively blacklist System.nanoTime()
- currently the accuracy / precision of the system calls inside a sandbox is very bad and so prevent naturally the attack.
- at this moment, no Spectre/Meltdown attack is possible using groovy sandbox

Compared to the script console, the granularity is 1000x for the sandbox version.

[SECURITY-683](https://issues.jenkins-ci.org/browse/SECURITY-683) (CERT team access only)

@reviewbybees @jglick
  