### PR TITLE
Improve UX in case of new dangerous signatures

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -824,23 +824,19 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
     @JavaScriptMethod public synchronized String[][] clearDangerousApprovedSignatures() throws IOException {
         Jenkins.getInstance().checkPermission(Jenkins.RUN_SCRIPTS);
 
-        TreeSet<String> newApprovedSignatures = new TreeSet<>();
-        for (String signature : approvedSignatures) {
-            if(!StaticWhitelist.isBlacklisted(signature)){
-                newApprovedSignatures.add(signature);
+        Iterator<String> it = approvedSignatures.iterator();
+        while (it.hasNext()) {
+            if (StaticWhitelist.isBlacklisted(it.next())) {
+                it.remove();
             }
         }
-        approvedSignatures.clear();
-        approvedSignatures.addAll(newApprovedSignatures);
 
-        TreeSet<String> newAclApprovedSignatures = new TreeSet<>();
-        for (String signature : aclApprovedSignatures) {
-            if(!StaticWhitelist.isBlacklisted(signature)){
-                newAclApprovedSignatures.add(signature);
+        it = aclApprovedSignatures.iterator();
+        while (it.hasNext()) {
+            if (StaticWhitelist.isBlacklisted(it.next())) {
+                it.remove();
             }
         }
-        aclApprovedSignatures.clear();
-        aclApprovedSignatures.addAll(newAclApprovedSignatures);
 
         save();
         return reconfigure();

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -819,6 +819,32 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
         // Should be [[], []] but still returning it for consistency with approve methods.
         return reconfigure();
     }
+    
+    @Restricted(NoExternalUse.class) // for use from AJAX
+    @JavaScriptMethod public synchronized String[][] clearDangerousApprovedSignatures() throws IOException {
+        Jenkins.getInstance().checkPermission(Jenkins.RUN_SCRIPTS);
+
+        TreeSet<String> newApprovedSignatures = new TreeSet<>();
+        for (String signature : approvedSignatures) {
+            if(!StaticWhitelist.isBlacklisted(signature)){
+                newApprovedSignatures.add(signature);
+            }
+        }
+        approvedSignatures.clear();
+        approvedSignatures.addAll(newApprovedSignatures);
+
+        TreeSet<String> newAclApprovedSignatures = new TreeSet<>();
+        for (String signature : aclApprovedSignatures) {
+            if(!StaticWhitelist.isBlacklisted(signature)){
+                newAclApprovedSignatures.add(signature);
+            }
+        }
+        aclApprovedSignatures.clear();
+        aclApprovedSignatures.addAll(newAclApprovedSignatures);
+
+        save();
+        return reconfigure();
+    }
 
     @Restricted(NoExternalUse.class)
     public synchronized List<ApprovedClasspathEntry> getApprovedClasspathEntries() {

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
@@ -250,8 +250,7 @@ THE SOFTWARE.
             </p>
             <j:if test="${!empty(dangerousApprovedSignatures)}">
                 Or you can just remove the dangerous ones:
-                <button onclick="if (confirm('Really delete all dangerous approvals? Any scripts that was using such signatures will need to be rerun and signatures reapproved.')) {clearDangerousApprovedSignatures()}">Clear only dangerous Approvals</button>
-
+                <button onclick="clearDangerousApprovedSignatures()">Clear only dangerous Approvals</button>
             </j:if>
             <hr/>
             <p id="pendingClasspathEntries-none">

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
@@ -70,6 +70,11 @@ THE SOFTWARE.
                         updateApprovedSignatures(r);
                     });
                 }
+                function clearDangerousApprovedSignatures() {
+                    mgr.clearDangerousApprovedSignatures(function(r) {
+                        updateApprovedSignatures(r);
+                    });
+                }
                 
                 function renderPendingClasspathEntries(pendingClasspathEntries) {
                     if (pendingClasspathEntries.length == 0) {
@@ -243,6 +248,11 @@ THE SOFTWARE.
                 You can also remove all previous signature approvals:
                 <button onclick="if (confirm('Really delete all approvals? Any existing scripts will need to be rerun and signatures reapproved.')) {clearApprovedSignatures()}">Clear Approvals</button>
             </p>
+            <j:if test="${!empty(dangerousApprovedSignatures)}">
+                Or you can just remove the dangerous ones:
+                <button onclick="if (confirm('Really delete all dangerous approvals? Any scripts that was using such signatures will need to be rerun and signatures reapproved.')) {clearDangerousApprovedSignatures()}">Clear only dangerous Approvals</button>
+
+            </j:if>
             <hr/>
             <p id="pendingClasspathEntries-none">
                 No pending classpath entry approvals.

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
@@ -54,6 +54,7 @@ public class ScriptApprovalTest extends AbstractApprovalTest<ScriptApprovalTest.
 
     private static final AtomicLong COUNTER = new AtomicLong(0L);
 
+    private static final String WHITELISTED_SIGNATURE = "method java.lang.String trim";
     private static final String DANGEROUS_SIGNATURE = "staticMethod hudson.model.User current";
 
     @Test public void emptyScript() throws Exception {
@@ -101,6 +102,32 @@ public class ScriptApprovalTest extends AbstractApprovalTest<ScriptApprovalTest.
 
     @Test public void nothingHappening() throws Exception {
         assertThat(r.createWebClient().goTo("manage").getByXPath("//a[@href='scriptApproval']"), Matchers.empty());
+    }
+
+    @Test public void clearMethodsLifeCycle() throws Exception {
+        ScriptApproval sa = ScriptApproval.get();
+        assertEquals(0, sa.getApprovedSignatures().length);
+
+        sa.approveSignature(WHITELISTED_SIGNATURE);
+        assertEquals(1, sa.getApprovedSignatures().length);
+        assertEquals(0, sa.getDangerousApprovedSignatures().length);
+        
+        sa.approveSignature(DANGEROUS_SIGNATURE);
+        assertEquals(2, sa.getApprovedSignatures().length);
+        assertEquals(1, sa.getDangerousApprovedSignatures().length);
+        
+        sa.clearApprovedSignatures();
+        assertEquals(0, sa.getApprovedSignatures().length);
+        assertEquals(0, sa.getDangerousApprovedSignatures().length);
+    
+        sa.approveSignature(WHITELISTED_SIGNATURE);
+        sa.approveSignature(DANGEROUS_SIGNATURE);
+        assertEquals(2, sa.getApprovedSignatures().length);
+        assertEquals(1, sa.getDangerousApprovedSignatures().length);
+        
+        sa.clearDangerousApprovedSignatures();
+        assertEquals(1, sa.getApprovedSignatures().length);
+        assertEquals(0, sa.getDangerousApprovedSignatures().length);
     }
 
     private Script script(String groovy) {


### PR DESCRIPTION
- add a button to only clear the dangerous signature that were approved instead of clearing everything
- add a test on the clear methods

~No associated ticket.~ Part of [JENKINS-22660](https://issues.jenkins-ci.org/browse/JENKINS-22660)

@reviewbybees @jglick 

  