### PR TITLE
Optimize whitelist check by using caching in ProxyWhitelist

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/Whitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/Whitelist.java
@@ -36,6 +36,8 @@ import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Determines which methods and similar members which scripts may call.
@@ -87,6 +89,7 @@ public abstract class Whitelist implements ExtensionPoint {
         return o == null ? "null" : getName(o.getClass());
     }
 
+    @Restricted(NoExternalUse.class)
     public static String[] argumentTypes(Class<?>[] argumentTypes) {
         String[] s = new String[argumentTypes.length];
         for (int i = 0; i < argumentTypes.length; i++) {
@@ -96,36 +99,44 @@ public abstract class Whitelist implements ExtensionPoint {
     }
 
     /** Canonical name for a field access. */
+    @Restricted(NoExternalUse.class)
     public static String canonicalFieldString(@Nonnull Field field) {
         return getName(field.getDeclaringClass()) + ' ' + field.getName();
     }
 
     /** Canonical name for a method call. */
+    @Restricted(NoExternalUse.class)
     public static String canonicalMethodString(@Nonnull Method method) {
         return joinWithSpaces(new StringBuilder(getName(method.getDeclaringClass())).append(' ').append(method.getName()), argumentTypes(method.getParameterTypes())).toString();
     }
 
     /** Canonical name for a constructor call. */
+    @Restricted(NoExternalUse.class)
     public static String canonicalConstructorString(@Nonnull Constructor cons) {
         return joinWithSpaces(new StringBuilder(getName(cons.getDeclaringClass())).append(' ').append(cons.getName()), argumentTypes(cons.getParameterTypes())).toString();
     }
 
+    @Restricted(NoExternalUse.class)
     public static String canonicalMethodSig(@Nonnull Method method) {
         return "method "+canonicalMethodString(method);
     }
 
+    @Restricted(NoExternalUse.class)
     public static String canonicalStaticMethodSig(@Nonnull Method method) {
         return "staticMethod "+canonicalMethodString(method);
     }
 
+    @Restricted(NoExternalUse.class)
     public static String canonicalConstructorSig(@Nonnull Constructor cons) {
         return "new "+canonicalConstructorString(cons);
     }
 
+    @Restricted(NoExternalUse.class)
     public static String canonicalFieldSig(@Nonnull Field field) {
         return "field "+canonicalFieldString(field);
     }
 
+    @Restricted(NoExternalUse.class)
     public static String canonicalStaticFieldSig(@Nonnull Field field) {
         return "staticField "+canonicalFieldString(field);
     }

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/Whitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/Whitelist.java
@@ -100,9 +100,34 @@ public abstract class Whitelist implements ExtensionPoint {
         return getName(field.getDeclaringClass()) + ' ' + field.getName();
     }
 
-    /** Canonical name for a field access. */
+    /** Canonical name for a method call. */
     public static String canonicalMethodString(@Nonnull Method method) {
         return joinWithSpaces(new StringBuilder(getName(method.getDeclaringClass())).append(' ').append(method.getName()), argumentTypes(method.getParameterTypes())).toString();
+    }
+
+    /** Canonical name for a constructor call. */
+    public static String canonicalConstructorString(@Nonnull Constructor cons) {
+        return joinWithSpaces(new StringBuilder(getName(cons.getDeclaringClass())).append(' ').append(cons.getName()), argumentTypes(cons.getParameterTypes())).toString();
+    }
+
+    public static String canonicalMethodSig(@Nonnull Method method) {
+        return "method "+canonicalMethodString(method);
+    }
+
+    public static String canonicalStaticMethodSig(@Nonnull Method method) {
+        return "staticMethod "+canonicalMethodString(method);
+    }
+
+    public static String canonicalConstructorSig(@Nonnull Constructor cons) {
+        return "new "+canonicalConstructorString(cons);
+    }
+
+    public static String canonicalFieldSig(@Nonnull Field field) {
+        return "field "+canonicalFieldString(field);
+    }
+
+    public static String canonicalStaticFieldSig(@Nonnull Field field) {
+        return "staticField "+canonicalFieldString(field);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/Whitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/Whitelist.java
@@ -66,6 +66,45 @@ public abstract class Whitelist implements ExtensionPoint {
 
     public abstract boolean permitsStaticFieldSet(@Nonnull Field field, @CheckForNull Object value);
 
+    // Utility methods for creating canonical string representations of the signature
+    public static final StringBuilder joinWithSpaces(StringBuilder b, String[] types) {
+        for (String type : types) {
+            b.append(' ').append(type);
+        }
+        return b;
+    }
+
+    public static @Nonnull String getName(@Nonnull Class<?> c) {
+        Class<?> e = c.getComponentType();
+        if (e == null) {
+            return c.getName();
+        } else {
+            return getName(e) + "[]";
+        }
+    }
+
+    public static @Nonnull String getName(@CheckForNull Object o) {
+        return o == null ? "null" : getName(o.getClass());
+    }
+
+    public static String[] argumentTypes(Class<?>[] argumentTypes) {
+        String[] s = new String[argumentTypes.length];
+        for (int i = 0; i < argumentTypes.length; i++) {
+            s[i] = getName(argumentTypes[i]);
+        }
+        return s;
+    }
+
+    /** Canonical name for a field access. */
+    public static String canonicalFieldString(@Nonnull Field field) {
+        return getName(field.getDeclaringClass()) + ' ' + field.getName();
+    }
+
+    /** Canonical name for a field access. */
+    public static String canonicalMethodString(@Nonnull Method method) {
+        return joinWithSpaces(new StringBuilder(getName(method.getDeclaringClass())).append(' ').append(method.getName()), argumentTypes(method.getParameterTypes())).toString();
+    }
+
     /**
      * Checks for all whitelists registered as {@link Extension}s and aggregates them.
      * @return an aggregated default list

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/AnnotatedWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/AnnotatedWhitelist.java
@@ -38,7 +38,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * Whitelists anything marked with {@link Whitelisted}.
  */
 @Restricted(NoExternalUse.class)
-@Extension public final class AnnotatedWhitelist extends AclAwareWhitelist implements CacheableWhitelist {
+@Extension public final class AnnotatedWhitelist extends AclAwareWhitelist {
 
     public AnnotatedWhitelist() {
         super(new Impl(false), new Impl(true));

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/AnnotatedWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/AnnotatedWhitelist.java
@@ -38,7 +38,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * Whitelists anything marked with {@link Whitelisted}.
  */
 @Restricted(NoExternalUse.class)
-@Extension public final class AnnotatedWhitelist extends AclAwareWhitelist {
+@Extension public final class AnnotatedWhitelist extends AclAwareWhitelist implements CacheableWhitelist {
 
     public AnnotatedWhitelist() {
         super(new Impl(false), new Impl(true));

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/BlanketWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/BlanketWhitelist.java
@@ -33,7 +33,7 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
  * Whitelists everything.
  * This is probably only useful for tests.
  */
-public final class BlanketWhitelist extends Whitelist {
+public final class BlanketWhitelist extends Whitelist implements CacheableWhitelist {
 
     @Override public boolean permitsMethod(Method method, Object receiver, Object[] args) {
         return true;

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/CacheableWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/CacheableWhitelist.java
@@ -2,7 +2,8 @@ package org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists;
 
 /**
  * Marker interface indicating results of permission checks do not change unless the list of entries is modified
- *  and depend ONLY on the Field/Method/Constructor actually being invoked.
+ *  and depend ONLY on the Field/Method/Constructor actually being invoked, irrespective of classloader.
+ *  That means you must be able to represent the WhiteList entry with a String signature of className + method/field signature.
  * @author Sam Van Oort
  */
 public interface CacheableWhitelist {

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/CacheableWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/CacheableWhitelist.java
@@ -1,0 +1,9 @@
+package org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists;
+
+/**
+ * Marker interface indicating results of permission checks do not change unless the list of entries is modified
+ *  and depend ONLY on the Field/Method/Constructor actually being invoked.
+ * @author Sam Van Oort
+ */
+public interface CacheableWhitelist {
+}

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/EnumeratingWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/EnumeratingWhitelist.java
@@ -115,27 +115,6 @@ public abstract class EnumeratingWhitelist extends Whitelist {
         return false;
     }
 
-    public static @Nonnull String getName(@Nonnull Class<?> c) {
-        Class<?> e = c.getComponentType();
-        if (e == null) {
-            return c.getName();
-        } else {
-            return getName(e) + "[]";
-        }
-    }
-
-    public static @Nonnull String getName(@CheckForNull Object o) {
-        return o == null ? "null" : getName(o.getClass());
-    }
-
-    private static String[] argumentTypes(Class<?>[] argumentTypes) {
-        String[] s = new String[argumentTypes.length];
-        for (int i = 0; i < argumentTypes.length; i++) {
-            s[i] = getName(argumentTypes[i]);
-        }
-        return s;
-    }
-
     private static boolean is(String thisIdentifier, String identifier) {
         return thisIdentifier.equals("*") || identifier.equals(thisIdentifier);
     }
@@ -143,12 +122,7 @@ public abstract class EnumeratingWhitelist extends Whitelist {
     public static abstract class Signature implements Comparable<Signature> {
         /** Form as in {@link StaticWhitelist} entries. */
         @Override public abstract String toString();
-        final StringBuilder joinWithSpaces(StringBuilder b, String[] types) {
-            for (String type : types) {
-                b.append(' ').append(type);
-            }
-            return b;
-        }
+
         abstract String signaturePart();
         @Override public int compareTo(Signature o) {
             int r = signaturePart().compareTo(o.signaturePart());

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/EnumeratingWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/EnumeratingWhitelist.java
@@ -38,7 +38,7 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
 /**
  * A whitelist based on listing signatures and searching them.
  */
-public abstract class EnumeratingWhitelist extends Whitelist {
+public abstract class EnumeratingWhitelist extends Whitelist implements CacheableWhitelist {
 
     protected abstract List<MethodSignature> methodSignatures();
 

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/GenericWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/GenericWhitelist.java
@@ -33,7 +33,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * Includes entries useful for general kinds of scripts.
  */
 @Restricted(NoExternalUse.class)
-@Extension public final class GenericWhitelist extends ProxyWhitelist {
+@Extension public final class GenericWhitelist extends ProxyWhitelist implements CacheableWhitelist {
 
     public GenericWhitelist() throws IOException {
         super(StaticWhitelist.from(GenericWhitelist.class.getResource("generic-whitelist")));

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/JenkinsWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/JenkinsWhitelist.java
@@ -33,7 +33,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * Includes entries useful for scripts accessing the Jenkins API, such as model objects.
  */
 @Restricted(NoExternalUse.class)
-@Extension public final class JenkinsWhitelist extends ProxyWhitelist {
+@Extension public final class JenkinsWhitelist extends ProxyWhitelist implements CacheableWhitelist {
 
     public JenkinsWhitelist() throws IOException {
         super(StaticWhitelist.from(JenkinsWhitelist.class.getResource("jenkins-whitelist")));

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/ProxyWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/ProxyWhitelist.java
@@ -56,7 +56,7 @@ import java.util.WeakHashMap;
  *
  * <ol>
  *     <li>First, we generate a String signature specific to the Field/Method/Constructor call type</li>
- *     <li>Then, this signature is used to check the cache {@link #permittedCache} - a stored "true" indicates that one of the CacheableWhitelist entries approved the method so it is always safe.</li>
+ *     <li>Then, this signature is used to check the cache (field permittedCache) - a stored "true" indicates that one of the CacheableWhitelist entries approved the method so it is always safe.</li>
  *     <li>A stored "false" value is a bit more subtle:
  *      <ol>
  *          <li>It means we can SKIP the CacheableWhitelists entirely because we know none of them approved the call.</li>

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/ProxyWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/ProxyWhitelist.java
@@ -28,14 +28,9 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
 
-import javax.sql.rowset.Predicate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
@@ -52,7 +52,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 /**
  * Whitelist based on a static file.
  */
-public final class StaticWhitelist extends EnumeratingWhitelist {
+public final class StaticWhitelist extends EnumeratingWhitelist implements CacheableWhitelist {
 
     final List<MethodSignature> methodSignatures = new ArrayList<MethodSignature>();
     final List<NewSignature> newSignatures = new ArrayList<NewSignature>();

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -667,7 +667,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
     }
 
     @Restricted(NoExternalUse.class) // implementation
-    @Extension public static final class ApprovedWhitelist extends ProxyWhitelist implements CacheableWhitelist {
+    @Extension public static final class ApprovedWhitelist extends ProxyWhitelist {
         public ApprovedWhitelist() {
             try {
                 reconfigure();

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.scriptsecurity.scripts;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.AclAwareWhitelist;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.CacheableWhitelist;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist;
@@ -666,7 +667,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
     }
 
     @Restricted(NoExternalUse.class) // implementation
-    @Extension public static final class ApprovedWhitelist extends ProxyWhitelist {
+    @Extension public static final class ApprovedWhitelist extends ProxyWhitelist implements CacheableWhitelist {
         public ApprovedWhitelist() {
             try {
                 reconfigure();


### PR DESCRIPTION
We generate a canonical string handle for lookup describing the Constructor/method call/etc and use that so we don't have to do an exhaustive whitelist search. 

Not sure what if anything more is needed for tests, since the methods are fairly directly invoked -- open to ideas here?

After the patches in https://github.com/jenkinsci/structs-plugin/pull/30 and https://github.com/jenkinsci/structs-plugin/pull/31 this has the most lock contention in pipeline -- with 40 pipelines running at once, 'delegates' spends a lot of time locked and blocking other pipelines.

If we want people to be able to run lots of pipelines at once, this is a must-have.