### PR TITLE
Replace "unclassified ..." error messages with something more helpful

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptor.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptor.java
@@ -141,7 +141,7 @@ final class SandboxInterceptor extends GroovyInterceptor {
     @Override public Object onNewInstance(GroovyInterceptor.Invoker invoker, Class receiver, Object... args) throws Throwable {
         Constructor<?> c = GroovyCallSiteSelector.constructor(receiver, args);
         if (c == null) {
-            throw new RejectedAccessException("unclassified new " + EnumeratingWhitelist.getName(receiver) + printArgumentTypes(args));
+            throw new RejectedAccessException("No such constructor found: new " + EnumeratingWhitelist.getName(receiver) + printArgumentTypes(args));
         } else if (whitelist.permitsConstructor(c, args)) {
             return super.onNewInstance(invoker, receiver, args);
         } else {
@@ -153,7 +153,7 @@ final class SandboxInterceptor extends GroovyInterceptor {
         Method m = GroovyCallSiteSelector.staticMethod(receiver, method, args);
         if (m == null) {
             // TODO consider DefaultGroovyStaticMethods
-            throw new RejectedAccessException("unclassified staticMethod " + EnumeratingWhitelist.getName(receiver) + " " + method + printArgumentTypes(args));
+            throw new RejectedAccessException("No such static method found: staticMethod " + EnumeratingWhitelist.getName(receiver) + " " + method + printArgumentTypes(args));
         } else if (whitelist.permitsStaticMethod(m, args)) {
             return super.onStaticCall(invoker, receiver, method, args);
         } else {
@@ -385,7 +385,7 @@ final class SandboxInterceptor extends GroovyInterceptor {
     public Object onSuperCall(Invoker invoker, Class senderType, Object receiver, String method, Object... args) throws Throwable {
         Method m = GroovyCallSiteSelector.method(receiver, method, args);
         if (m == null) {
-            throw new RejectedAccessException("unclassified super.method " + EnumeratingWhitelist.getName(receiver.getClass()) + " " + method + printArgumentTypes(args));
+            throw new RejectedAccessException("No such method found: super.method " + EnumeratingWhitelist.getName(receiver.getClass()) + " " + method + printArgumentTypes(args));
         } else if (whitelist.permitsMethod(m, receiver, args)) {
             return super.onSuperCall(invoker, senderType, receiver, method, args);
         } else {
@@ -394,7 +394,7 @@ final class SandboxInterceptor extends GroovyInterceptor {
     }
 
     private static RejectedAccessException unclassifiedField(Object receiver, String property) {
-        return new RejectedAccessException("unclassified field " + EnumeratingWhitelist.getName(receiver.getClass()) + " " + property);
+        return new RejectedAccessException("No such field found: field " + EnumeratingWhitelist.getName(receiver.getClass()) + " " + property);
     }
 
     // TODO Java 8: @FunctionalInterface
@@ -448,7 +448,7 @@ final class SandboxInterceptor extends GroovyInterceptor {
                 }
             }
         }
-        throw new RejectedAccessException("unclassified getAt method " + EnumeratingWhitelist.getName(receiver) + "[" + EnumeratingWhitelist.getName(index) + "]");
+        throw new RejectedAccessException("No such getAt method found: method " + EnumeratingWhitelist.getName(receiver) + "[" + EnumeratingWhitelist.getName(index) + "]");
     }
 
     @Override public Object onSetArray(Invoker invoker, Object receiver, Object index, Object value) throws Throwable {
@@ -475,7 +475,7 @@ final class SandboxInterceptor extends GroovyInterceptor {
                 }
             }
         }
-        throw new RejectedAccessException("unclassified putAt method " + EnumeratingWhitelist.getName(receiver) + "[" + EnumeratingWhitelist.getName(index) + "]=" + EnumeratingWhitelist.getName(value));
+        throw new RejectedAccessException("No such putAt method found: putAt method " + EnumeratingWhitelist.getName(receiver) + "[" + EnumeratingWhitelist.getName(index) + "]=" + EnumeratingWhitelist.getName(value));
     }
 
     private static String printArgumentTypes(Object[] args) {

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -225,14 +225,14 @@ public class SandboxInterceptorTest {
             fail();
         } catch (RejectedAccessException x) {
             assertEquals(null, x.getSignature());
-            assertEquals("unclassified field " + clazz + " nonexistent", x.getMessage());
+            assertEquals("No such field found: field " + clazz + " nonexistent", x.getMessage());
         }
         try {
             evaluate(new StaticWhitelist("new " + clazz), "new " + clazz + "().nonexistent = 'edited'");
             fail();
         } catch (RejectedAccessException x) {
             assertEquals(null, x.getSignature());
-            assertEquals("unclassified field " + clazz + " nonexistent", x.getMessage());
+            assertEquals("No such field found: field " + clazz + " nonexistent", x.getMessage());
         }
         assertRejected(new StaticWhitelist("new " + clazz), "method " + clazz + " getProp5", "new " + clazz + "().prop5");
         assertEvaluate(new StaticWhitelist("new " + clazz, "method " + clazz + " getProp5"), "DEFAULT", "new " + clazz + "().prop5");


### PR DESCRIPTION
Not a *ton* more helpful, but I think it's better than just "unclassified ...".

I've seen enough cases of people (including myself) getting confused by what "unclassified ..." means that it feels like explaining that it means we couldn't find that particular field/constructor/method/etc is better than being vague. That said, I know it's not *quite* right in all cases, so I need to think on it more.

cc @reviewbybees 