### PR TITLE
[FIXED JENKINS-50470] Treat someList.someField as spread.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>groovy-sandbox</artifactId>
-      <version>1.19-20180330.134914-2</version> <!-- TODO: https://github.com/jenkinsci/groovy-sandbox/pull/46 -->
+      <version>1.19</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>groovy-sandbox</artifactId>
-      <version>1.18</version>
+      <version>1.19-20180329.140543-1</version> <!-- TODO: https://github.com/jenkinsci/groovy-sandbox/pull/46 -->
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>groovy-sandbox</artifactId>
-      <version>1.19-20180329.140543-1</version> <!-- TODO: https://github.com/jenkinsci/groovy-sandbox/pull/46 -->
+      <version>1.19-20180330.134914-2</version> <!-- TODO: https://github.com/jenkinsci/groovy-sandbox/pull/46 -->
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
[JENKINS-50470](https://issues.jenkins-ci.org/browse/JENKINS-50470)

See upstream PR at https://github.com/jenkinsci/groovy-sandbox/pull/46, but the gist is that Groovy's normal behavior for this is to treat it the same as we do spread cases - iterate over the list to get the value from each object in the list and return the resulting list.

cc @reviewbybees 