### PR TITLE
JENKINS-46882 allow new Exceptions to be thrown

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -53,6 +53,7 @@ method java.lang.Comparable compareTo java.lang.Object
 new java.lang.Enum java.lang.String int
 method java.lang.Enum name
 method java.lang.Enum ordinal
+new java.lang.Exception java.lang.String
 staticField java.lang.Integer MAX_VALUE
 # could add valueOf, though currently the staticField’s need to be whitelisted, which is the more likely use case
 staticMethod java.lang.Integer parseInt java.lang.String


### PR DESCRIPTION
new Execption("foo") is currently not permitted, but is very useful to do and is a standard/safe thing in a Jenkinsfile

The funny thing is that throwing an explicit exception with a custom message actually results in:
`Scripts not permitted to use new java.lang.Exception java.lang.String` as an exception ...

In issue JENKINS-46882 @abayer indicated that adding this to the whitelist would be acceptable, hence the PR.