### PR TITLE
Allow calling Closure elements of Maps as methods

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptor.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptor.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
 
 import com.google.common.collect.ImmutableSet;
+import groovy.lang.Closure;
 import groovy.lang.GroovyRuntimeException;
 import groovy.lang.MetaMethod;
 import groovy.lang.MissingMethodException;
@@ -35,6 +36,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -112,6 +114,14 @@ final class SandboxInterceptor extends GroovyInterceptor {
             // we're iterating over the whole list before we decide to fail out on the first failure we found.
             if (foundDgmMethod != null) {
                 throw StaticWhitelist.rejectStaticMethod(foundDgmMethod);
+            }
+
+            // allow calling Closure elements of Maps as methods
+            if (receiver instanceof Map) {
+                Object element = onMethodCall(invoker, receiver, "get", method);
+                if (element instanceof Closure) {
+                    return onMethodCall(invoker, element, "call", args);
+                }
             }
 
             // if no matching method, look for catchAll "invokeMethod"

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -1080,4 +1080,10 @@ public class SandboxInterceptorTest {
                 "def l = [new " + snb + "('a'), new " + snb +"('b'), new " + snb + "('c')]\n" +
                         "return l.other\n");
     }
+
+    @Issue("JENKINS-50843")
+    @Test
+    public void callClosureElementOfMapAsMethod() throws Exception {
+        assertEvaluate(new GenericWhitelist(), "hello", "def m = [ f: {return 'hello'} ]; m.f()");
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -1085,5 +1085,8 @@ public class SandboxInterceptorTest {
     @Test
     public void callClosureElementOfMapAsMethod() throws Exception {
         assertEvaluate(new GenericWhitelist(), "hello", "def m = [ f: {return 'hello'} ]; m.f()");
+        assertEvaluate(new GenericWhitelist(), 15, "def m = [ f: {a -> return a*3} ]; m.f(5)");
+        assertEvaluate(new GenericWhitelist(), "a=hello,b=10", "def m = [ f: {a,b -> return \"a=${a},b=${b}\"} ]; m.f('hello',10)");
+        assertEvaluate(new GenericWhitelist(), 2, "def m = [ f: {it.size()} ]; m.f(foo:0, bar:1)");
     }
 }


### PR DESCRIPTION
The sandbox rejects valid Groovy code when trying to call a Closure element of a Map as if it were one of the Map's methods. See [JENKINS-50843](https://issues.jenkins-ci.org/browse/JENKINS-50843).