### PR TITLE
Whitelist: add jsonbuilder

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -13,6 +13,7 @@ staticMethod groovy.json.JsonOutput toJson java.util.Date
 staticMethod groovy.json.JsonOutput toJson java.util.Map
 staticMethod groovy.json.JsonOutput toJson java.util.UUID
 new groovy.json.JsonSlurper
+new groovy.json.JsonBuilder java.lang.Object
 method groovy.json.JsonSlurper parseText java.lang.String
 
 method groovy.lang.Binding hasVariable java.lang.String


### PR DESCRIPTION
This should allow code such as:

```groovy
new groovy.json.JsonBuilder([
    some: "value",
    iwant: "json",
    pls: "jenkins"
]).toString() 
```

Which is a fairly common use case, e.g., in posting data to a url (for notifications) in post-build actions.