### PR TITLE
[FIXED JENKINS-50906] Allow foo() for Script binding closure variables

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptor.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptor.java
@@ -124,6 +124,15 @@ final class SandboxInterceptor extends GroovyInterceptor {
                 }
             }
 
+            // Allow calling closure variables from a script binding as methods
+            if (receiver instanceof Script) {
+                Script s = (Script)receiver;
+                Object var = s.getBinding().getVariable(method);
+                if (var instanceof Closure) {
+                    return onMethodCall(invoker, var, "call", args);
+                }
+            }
+
             // if no matching method, look for catchAll "invokeMethod"
             try {
                 receiver.getClass().getMethod("invokeMethod", String.class, Object.class);

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -1089,4 +1089,10 @@ public class SandboxInterceptorTest {
         assertEvaluate(new GenericWhitelist(), "a=hello,b=10", "def m = [ f: {a,b -> return \"a=${a},b=${b}\"} ]; m.f('hello',10)");
         assertEvaluate(new GenericWhitelist(), 2, "def m = [ f: {it.size()} ]; m.f(foo:0, bar:1)");
     }
+
+    @Issue("JENKINS-50906")
+    @Test
+    public void scriptBindingClosureVariableCall() throws Exception {
+        assertEvaluate(new GenericWhitelist(), true, "def func = { 1 }; this.func2 = { 1 }; return func() == func2();\n");
+    }
 }


### PR DESCRIPTION
[JENKINS-50906](https://issues.jenkins-ci.org/browse/JENKINS-50906)

Interestingly, this doesn't show up in Pipeline, just in vanilla sandboxed Groovy scripts.
