### PR TITLE
[JENKINS-46757] Turn on now-working test.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -605,7 +605,6 @@ public class SandboxInterceptorTest {
         }
     }
 
-    @Ignore("TODO last fails with: RejectedAccessException: Scripts not permitted to use new java.util.Properties java.util.Properties")
     @Issue("JENKINS-46757")
     @Test public void properties() throws Exception {
         String script = "def properties = new Properties()";


### PR DESCRIPTION
[JENKINS-46757](https://issues.jenkins-ci.org/browse/JENKINS-46757)

This was actually fixed in JENKINS-50380, in release 1.43.