### PR TITLE
Created a "glue-code" for casc plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.60.3'])
+buildPlugin(jenkinsVersions: [null])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null])
+buildPlugin()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(jenkinsVersions: ['2.60.3'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.60.2'])
+buildPlugin(jenkinsVersions: [null, '2.7.3'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.7.3'])
+buildPlugin(jenkinsVersions: [null, '2.60.3'])

--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,5 @@
       <version>${version.configuration-as-code}</version>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>io.jenkins.configuration-as-code</groupId>
-      <artifactId>configuration-as-code-support</artifactId>
-      <version>${version.configuration-as-code}</version>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,7 @@
       <changelist>-SNAPSHOT</changelist>
       <jenkins.version>2.60.3</jenkins.version>
       <java.level>8</java.level>
-      <!-- TODO: Remove usBeta once the casc plugin will be released -->
-      <useBeta>true</useBeta>
-      <configuration-as-code.version>1.0</configuration-as-code.version>
+      <configuration-as-code.version>1.1</configuration-as-code.version>
     </properties>
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,10 @@
       <revision>1.47</revision>
       <changelist>-SNAPSHOT</changelist>
       <jenkins.version>2.7.3</jenkins.version>
-      <java.level>7</java.level>
+      <java.level>8</java.level>
+      <!-- TODO: Remove usBeta once the casc plugin will be released -->
+      <useBeta>true</useBeta>
+      <version.configuration-as-code>1.0-rc2</version.configuration-as-code>
     </properties>
     <licenses>
         <license>
@@ -57,6 +60,18 @@
           <artifactId>groovy</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${version.configuration-as-code}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>configuration-as-code-support</artifactId>
+      <version>${version.configuration-as-code}</version>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
     <properties>
       <revision>1.47</revision>
       <changelist>-SNAPSHOT</changelist>
-      <jenkins.version>2.7.3</jenkins.version>
+      <jenkins.version>2.60.3</jenkins.version>
       <java.level>8</java.level>
       <!-- TODO: Remove usBeta once the casc plugin will be released -->
       <useBeta>true</useBeta>
-      <version.configuration-as-code>1.0</version.configuration-as-code>
+      <configuration-as-code.version>1.0</configuration-as-code.version>
     </properties>
     <licenses>
         <license>
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${version.configuration-as-code}</version>
+      <version>${configuration-as-code.version}</version>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       <java.level>8</java.level>
       <!-- TODO: Remove usBeta once the casc plugin will be released -->
       <useBeta>true</useBeta>
-      <version.configuration-as-code>1.0-rc2</version.configuration-as-code>
+      <version.configuration-as-code>1.0</version.configuration-as-code>
     </properties>
     <licenses>
         <license>

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/casc/ScriptApprovalConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/casc/ScriptApprovalConfigurator.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  * @author <a href="mailto:ohad.david@gmail.com">Ohad David</a>
@@ -27,6 +28,7 @@ import java.util.Set;
 @Restricted(NoExternalUse.class)
 public class ScriptApprovalConfigurator extends BaseConfigurator<ScriptApproval> implements RootElementConfigurator<ScriptApproval> {
 
+    private static final Logger LOGGER = Logger.getLogger(ScriptApprovalConfigurator.class.getName());
 
     @Override
     public String getName() {
@@ -51,6 +53,7 @@ public class ScriptApprovalConfigurator extends BaseConfigurator<ScriptApproval>
         try {
             return target.approveSignature(signature);
         } catch (IOException e) {
+            LOGGER.warning("Could not approve signature: " + signature + " ScriptApproval threw IOException: " + e.getMessage());
             throw new UncheckedIOException(e);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/casc/ScriptApprovalConfigurator.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/casc/ScriptApprovalConfigurator.java
@@ -1,0 +1,77 @@
+package org.jenkinsci.plugins.scriptsecurity.casc;
+
+import hudson.Extension;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.BaseConfigurator;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.RootElementConfigurator;
+import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.CheckForNull;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:ohad.david@gmail.com">Ohad David</a>
+ */
+@Extension(optional = true)
+@Restricted(NoExternalUse.class)
+public class ScriptApprovalConfigurator extends BaseConfigurator<ScriptApproval> implements RootElementConfigurator<ScriptApproval> {
+
+
+    @Override
+    public String getName() {
+        return "scriptApproval";
+    }
+
+    @Override
+    public Class<ScriptApproval> getTarget() {
+        return ScriptApproval.class;
+    }
+
+    @Override
+    public Set<Attribute<ScriptApproval, ?>> describe() {
+        final Set<Attribute<ScriptApproval, ?>> describe = new HashSet<>();
+        describe.add(new MultivaluedAttribute<ScriptApproval, String>("approvedSignatures", String.class)
+                .getter((ScriptApproval target) -> Arrays.asList(target.getApprovedSignatures()))
+                .setter((target, value) -> value.forEach(signature -> uncheckedApproveSignature(target, signature))));
+        return describe;
+    }
+
+    private static String[][] uncheckedApproveSignature(ScriptApproval target, String signature) {
+        try {
+            return target.approveSignature(signature);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @CheckForNull
+    @Override
+    public CNode describe(ScriptApproval instance, ConfigurationContext context) throws Exception {
+        Mapping mapping = new Mapping();
+        for (Attribute attribute : describe()) {
+            mapping.put(attribute.getName(), attribute.describe(ScriptApproval.get(), context));
+        }
+        return mapping;
+    }
+
+    @Override
+    protected ScriptApproval instance(Mapping mapping, ConfigurationContext context) {
+        return ScriptApproval.get();
+    }
+
+    @Override
+    public ScriptApproval getTargetComponent(ConfigurationContext context) {
+        return ScriptApproval.get();
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/casc/ScriptApprovalConfiguratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/casc/ScriptApprovalConfiguratorTest.java
@@ -1,0 +1,31 @@
+package org.jenkinsci.plugins.scriptsecurity.casc;
+
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Arrays;
+
+/**
+ * @author <a href="mailto:ohad.david@gmail.com">Ohad David</a>
+ */
+public class ScriptApprovalConfiguratorTest {
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Test
+    public void testCascLoadFromYaml() throws Exception{
+        String resource = getClass().getResource("ScriptApprovalConfiguratorTest.yml").toExternalForm();
+        ConfigurationAsCode.get().configure(Arrays.asList(resource));
+        final ScriptApproval scriptApproval = ScriptApproval.get();
+        String[] signatures = scriptApproval.getApprovedSignatures();
+        Assert.assertArrayEquals(signatures, new String[]{
+                "method java.net.URI getHost",
+                "method java.net.URI getPort",
+                "new java.net.URI java.lang.String"
+        });
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/scriptsecurity/casc/ScriptApprovalConfiguratorTest.yml
+++ b/src/test/resources/org/jenkinsci/plugins/scriptsecurity/casc/ScriptApprovalConfiguratorTest.yml
@@ -1,0 +1,5 @@
+scriptApproval:
+  approvedSignatures:
+    - method java.net.URI getHost
+    - method java.net.URI getPort
+    - new java.net.URI java.lang.String


### PR DESCRIPTION
This PR enables the end user to configure method signature approvals using [casc plugin](https://github.com/jenkinsci/configuration-as-code-plugin)

See conversation in 
https://github.com/jenkinsci/configuration-as-code-plugin/pull/416#issuecomment-416973989

Since the casc plugin is still in beta, I've changed the pom to enable beta plugin dependencies. This property will/should be removed once the casc plugin 1.0 will be released