### PR TITLE
[WIP] Default whitelisting of build Cause methods to be exposed for pipeline developers (simple option)

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/jenkins-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/jenkins-whitelist
@@ -1,6 +1,16 @@
 # Useful Jenkins API methods:
+method com.cloudbees.jenkins.plugins.pipeline.events.EventTriggerCause getJson
 new hudson.EnvVars
 method hudson.model.AbstractBuild getEnvironments
+method hudson.model.Cause getShortDescription
+method hudson.model.Cause$RemoteCause getAddr
+method hudson.model.Cause$RemoteCause getNote
+method hudson.model.Cause$UpstreamCause getUpstreamBuild
+method hudson.model.Cause$UpstreamCause getUpstreamCauses
+method hudson.model.Cause$UpstreamCause getUpstreamProject
+method hudson.model.Cause$UserCause getUserName
+method hudson.model.Cause$UserIdCause getUserId
+method hudson.model.Cause$UserIdCause getUserName
 staticMethod hudson.model.Environment create hudson.EnvVars
 method hudson.model.Item getParent
 method hudson.model.ModelObject getDisplayName


### PR DESCRIPTION
**WIP**  **DO NOT MERGE**

This PR is associated with [https://github.com/jenkinsci/workflow-support-plugin/pull/73](https://github.com/jenkinsci/workflow-support-plugin/pull/73) for implementing a simple option for exposing build `Cause` objects in a safe manner for pipeline developers

This PR whitelists by default the methods we want to expose for the current `Cause` subclasses