### PR TITLE
FEAT: make ScriptApproval a GlobalConfiguration for CasC.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -24,6 +24,15 @@
 
 package org.jenkinsci.plugins.scriptsecurity.scripts;
 
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.AclAwareWhitelist;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.Util;
@@ -32,24 +41,6 @@ import hudson.model.RootAction;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.XStream2;
-import jenkins.model.GlobalConfiguration;
-import jenkins.model.Jenkins;
-import net.sf.json.JSON;
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
-import org.acegisecurity.context.SecurityContext;
-import org.acegisecurity.context.SecurityContextHolder;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.AclAwareWhitelist;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.bind.JavaScriptMethod;
-
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -73,11 +64,22 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
+import net.sf.json.JSON;
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.bind.JavaScriptMethod;
 
 /**
  * Manages approved scripts.
  */
-@Extension public class ScriptApproval extends GlobalConfiguration implements RootAction {
+@Symbol("scriptApproval")
+@Extension
+public class ScriptApproval extends GlobalConfiguration implements RootAction {
 
     private static final Logger LOG = Logger.getLogger(ScriptApproval.class.getName());
 

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -24,22 +24,32 @@
 
 package org.jenkinsci.plugins.scriptsecurity.scripts;
 
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.AclAwareWhitelist;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.Util;
 import hudson.XmlFile;
 import hudson.model.RootAction;
-import hudson.model.Saveable;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.XStream2;
+import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
+import net.sf.json.JSON;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.AclAwareWhitelist;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.bind.JavaScriptMethod;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -51,6 +61,7 @@ import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -62,19 +73,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import jenkins.model.Jenkins;
-import net.sf.json.JSON;
-import org.acegisecurity.context.SecurityContext;
-import org.acegisecurity.context.SecurityContextHolder;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.bind.JavaScriptMethod;
 
 /**
  * Manages approved scripts.
  */
-@Extension public class ScriptApproval implements RootAction, Saveable {
+@Extension public class ScriptApproval extends GlobalConfiguration implements RootAction {
 
     private static final Logger LOG = Logger.getLogger(ScriptApproval.class.getName());
 
@@ -90,6 +93,11 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
         XSTREAM2.alias("pendingScript", PendingScript.class);
         XSTREAM2.alias("pendingSignature", PendingSignature.class);
         XSTREAM2.alias("pendingClasspathEntry", PendingClasspathEntry.class);
+    }
+
+    @Override
+    protected XmlFile getConfigFile() {
+        return new XmlFile(XSTREAM2, new File(Jenkins.getInstance().getRootDir(),getUrlName() + ".xml"));
     }
 
     /** Gets the singleton instance. */
@@ -321,12 +329,9 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
         pendingClasspathEntries.add(pcp);
     }
 
+    @DataBoundConstructor
     public ScriptApproval() {
-        try {
-            load();
-        } catch (IOException x) {
-            LOG.log(Level.WARNING, null, x);
-        }
+        load();
         /* can be null when upgraded from old versions.*/
         if (aclApprovedSignatures == null) {
             aclApprovedSignatures = new TreeSet<String>();
@@ -346,11 +351,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
             }
         }
         if (changed) {
-            try {
-                save();
-            } catch (IOException x) {
-                LOG.log(Level.WARNING, "Unable to save changes after cleaning accepted class directories", x);
-            }
+            save();
         }
     }
 
@@ -438,11 +439,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
                 }
                 pendingScripts.add(new PendingScript(script, language, context));
             }
-            try {
-                save();
-            } catch (IOException x) {
-                LOG.log(Level.WARNING, null, x);
-            }
+            save();
         }
         return script;
     }
@@ -517,11 +514,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
                 }
             }
             if (shouldSave) {
-                try {
-                    save();
-                } catch (IOException x) {
-                    LOG.log(Level.WARNING, null, x);
-                }
+                save();
             }
         }
     }
@@ -573,11 +566,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
                 ApprovalContext context = ApprovalContext.create();
                 if (pendingClasspathEntries.add(new PendingClasspathEntry(hash, url, context))) {
                     LOG.log(Level.FINE, "{0} ({1}) is pending.", new Object[] {url, hash});
-                    try {
-                        save();
-                    } catch (IOException x) {
-                        LOG.log(Level.WARNING, null, x);
-                    }
+                    save();
                 }
             }
             throw new UnapprovedClasspathException(url, hash);
@@ -635,13 +624,17 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
     public synchronized RejectedAccessException accessRejected(@Nonnull RejectedAccessException x, @Nonnull ApprovalContext context) {
         String signature = x.getSignature();
         if (signature != null && pendingSignatures.add(new PendingSignature(signature, x.isDangerous(), context))) {
-            try {
-                save();
-            } catch (IOException x2) {
-                LOG.log(Level.WARNING, null, x2);
-            }
+            save();
         }
         return x;
+    }
+
+    @DataBoundSetter
+    public synchronized void setApprovedSignatures(String[] signatures) {
+        Jenkins.getInstance().checkPermission(Jenkins.RUN_SCRIPTS);
+        approvedSignatures.clear();
+        approvedSignatures.addAll(Arrays.asList(signatures));
+        save();
     }
 
     @Restricted(NoExternalUse.class) // Jelly, implementation
@@ -694,31 +687,6 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
 
     @Override public String getUrlName() {
         return "scriptApproval";
-    }
-
-    @CheckForNull
-    private XmlFile getConfigFile() {
-        final Jenkins jenkins = Jenkins.getInstanceOrNull();
-        if (jenkins == null) {
-            return null;
-        }
-        return new XmlFile(XSTREAM2, new File(jenkins.getRootDir(), getUrlName() + ".xml"));
-    }
-
-    private synchronized void load() throws IOException {
-        final XmlFile xml = getConfigFile();
-        if (xml != null && xml.exists()) {
-            xml.unmarshal(this);
-        }
-    }
-
-    @Override public synchronized void save() throws IOException {
-        final XmlFile configFile = getConfigFile();
-        if (configFile == null) {
-            throw new IOException("Cannot get config file. Probably, Jenkins is not ready");
-        }
-        configFile.write(this);
-        // TBD: outside synch block: SaveableListener.fireOnChange(this, getConfigFile());
     }
 
     @Restricted(NoExternalUse.class) // for use from Jelly

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -681,10 +681,6 @@ import javax.annotation.Nonnull;
         return null;
     }
 
-    @Override public String getDisplayName() {
-        return null;
-    }
-
     @Override public String getUrlName() {
         return "scriptApproval";
     }

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/config.jelly
@@ -1,0 +1,3 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+</j:jelly>


### PR DESCRIPTION
This PR enables Jenkins `scriptApproval.approvedSignatures` to be configured with CasC by following a different approach than https://github.com/jenkinsci/script-security-plugin/pull/219. 

Given we don't want to have glue code in this plugin, we need to make some modifications to `ScriptApproval` so that CasC can understand it. 

With this change users of CasC can now define the configuration as follows:
```
---
unclassified:
  scriptApproval:
    approvedSignatures:
    - method java.net.URI getHost
    - method java.net.URI getPort
    - new java.net.URI java.lang.String
```