### PR TITLE
[JENKINS-55411] Whitelist DateTimeFormatter.ofPattern(String)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
   </parent>
 
     <artifactId>script-security</artifactId>
-    <version>1.49</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Script Security Plugin</name>
     <description>Allows Jenkins administrators to control what in-process scripts can be run by less-privileged users.</description>
     <url>https://wiki.jenkins.io/display/JENKINS/Script+Security+Plugin</url>
     <properties>
-      <revision>1.49</revision>
+      <revision>1.50</revision>
       <changelist>-SNAPSHOT</changelist>
       <jenkins.version>2.7.3</jenkins.version>
       <java.level>7</java.level>
@@ -29,7 +29,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>script-security-1.49</tag>
+        <tag>${scmTag}</tag>
   </scm>
 
   <repositories>

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -224,6 +224,7 @@ staticField java.time.format.DateTimeFormatter ISO_TIME
 staticField java.time.format.DateTimeFormatter ISO_WEEK_DATE
 staticField java.time.format.DateTimeFormatter ISO_ZONED_DATE_TIME
 staticField java.time.format.DateTimeFormatter RFC_1123_DATE_TIME
+staticMethod java.time.format.DateTimeFormatter ofPattern java.lang.String
 new java.util.ArrayList java.util.Collection
 staticMethod java.util.Arrays asList java.lang.Object[]
 staticMethod java.util.Arrays toString java.lang.Object[]


### PR DESCRIPTION
Whitelisted [DateTimeFormatter.ofPattern(String)](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ofPattern-java.lang.String-) since currently we have only set of constants whitelisted (BASIC_ISO_DATE, ISO_DATE_TIME...) that doesn't cover all real-life use cases