### PR TITLE
[JENKINS-55303] Skip Memory test on JVM greater than Java 8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,10 @@
-buildPlugin(jenkinsVersions: [null, '2.60.2'])
+coreJdk11Version="2.164"
+
+buildPlugin(configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "8", jenkins: coreJdk11Version, javaLevel: "8" ],
+  [ platform: "windows", jdk: "8", jenkins: coreJdk11Version, javaLevel: "8" ],
+  [ platform: "linux", jdk: "11", jenkins: coreJdk11Version, javaLevel: "8" ],
+  [ platform: "windows", jdk: "11", jenkins: coreJdk11Version, javaLevel: "8" ]
+])

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.21</version>
+    <version>3.37</version>
     <relativePath />
   </parent>
 
@@ -57,6 +57,12 @@
           <artifactId>groovy</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>version-number</artifactId>
+      <version>1.6</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyMemoryLeakTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyMemoryLeakTest.java
@@ -2,11 +2,9 @@ package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
 
 import groovy.lang.MetaClass;
 import hudson.model.FreeStyleProject;
+import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import org.codehaus.groovy.reflection.ClassInfo;
-import org.junit.After;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
@@ -44,6 +42,8 @@ public class GroovyMemoryLeakTest {
 
     @Test
     public void loaderReleased() throws Exception {
+        Assume.assumeTrue(isRunningOnJDK8());
+
         FreeStyleProject p = r.jenkins.createProject(FreeStyleProject.class, "p");
         p.getPublishersList().add(new TestGroovyRecorder(
                 new SecureGroovyScript(GroovyMemoryLeakTest.class.getName()+".register(this)", false, null)));
@@ -61,5 +61,9 @@ public class GroovyMemoryLeakTest {
         for (WeakReference<ClassLoader> loaderRef : LOADERS) {
             MemoryAssert.assertGC(loaderRef, false);
         }
+    }
+
+    private boolean isRunningOnJDK8() {
+        return JavaSpecificationVersion.forCurrentJVM().isOlderThanOrEqualTo(JavaSpecificationVersion.JAVA_8);
     }
 }


### PR DESCRIPTION
[JENKINS-55303](https://issues.jenkins-ci.org/browse/JENKINS-55303)

Based on recommendation by @dwnusbaum to prevent false negative on tests on Java9+.

@jenkinsci/java11-support 