### PR TITLE
Workaround Javadoc issue on JDK 11.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.37</version>
+    <version>3.40</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
This is a followup for #238 in order to fix master branch.

Thank you @batmat for finding the reason behind this problem.