### PR TITLE
[JENKINS-56688] Add missing Map utility methods.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -320,7 +320,6 @@ method java.util.Map putIfAbsent java.lang.Object java.lang.Object
 method java.util.Map remove java.lang.Object
 method java.util.Map replace java.lang.Object java.lang.Object
 method java.util.Map replace java.lang.Object java.lang.Object java.lang.Object
-method java.util.Map replaceAll java.lang.Object
 method java.util.Map size
 method java.util.Map values
 method java.util.Map$Entry getKey

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -311,11 +311,16 @@ method java.util.Map clear
 method java.util.Map containsKey java.lang.Object
 method java.util.Map entrySet
 method java.util.Map get java.lang.Object
+method java.util.Map getOrDefault java.lang.Object java.lang.Object
 method java.util.Map isEmpty
 method java.util.Map keySet
 method java.util.Map put java.lang.Object java.lang.Object
 method java.util.Map putAll java.util.Map
+method java.util.Map putIfAbsent java.lang.Object java.lang.Object
 method java.util.Map remove java.lang.Object
+method java.util.Map replace java.lang.Object java.lang.Object
+method java.util.Map replace java.lang.Object java.lang.Object java.lang.Object
+method java.util.Map replaceAll java.lang.Object
 method java.util.Map size
 method java.util.Map values
 method java.util.Map$Entry getKey


### PR DESCRIPTION
These methods are needed for general usage and scripting.
They are easily emulated with the already approved
methods containsKey and get.