### PR TITLE
whitelist java.lang.management.ManagementFactory.getOperatingSystemMXBean

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -113,6 +113,7 @@ staticMethod java.lang.String valueOf java.lang.Object
 staticMethod java.lang.System currentTimeMillis
 method java.lang.Throwable getCause
 method java.lang.Throwable getMessage
+staticMethod java.lang.management.ManagementFactory getOperatingSystemMXBean
 new java.net.MalformedURLException java.lang.String
 new java.net.URL java.lang.String
 staticMethod java.net.URLDecoder decode java.lang.String java.lang.String


### PR DESCRIPTION
The read-only information returned provides useful information for architecture and OS, load information which could guide the necessary build/test.

All could be obtained with a bit more difficulty with shell scripts.

https://docs.oracle.com/javase/7/docs/api/java/lang/management/OperatingSystemMXBean.html