### PR TITLE
Always reject System.exit.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovySandbox.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovySandbox.java
@@ -52,6 +52,7 @@ import org.codehaus.groovy.control.Phases;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.Whitelist;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApprovalNote;
@@ -121,7 +122,10 @@ public final class GroovySandbox {
             if (ExtensionList.lookup(RootAction.class).get(ScriptApproval.class) == null) {
                 return; // running in unit test, ignore
             }
-            ScriptApproval.get().accessRejected(x, _context);
+            String signature = x.getSignature();
+            if (signature != null && !StaticWhitelist.isPermanentlyBlacklisted(signature)) {
+                ScriptApproval.get().accessRejected(x, _context);
+            }
             if (listener != null) {
                 ScriptApprovalNote.print(listener, x);
             }

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovySandbox.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovySandbox.java
@@ -123,7 +123,7 @@ public final class GroovySandbox {
                 return; // running in unit test, ignore
             }
             String signature = x.getSignature();
-            if (signature != null && !StaticWhitelist.isPermanentlyBlacklisted(signature)) {
+            if (!StaticWhitelist.isPermanentlyBlacklisted(signature)) {
                 ScriptApproval.get().accessRejected(x, _context);
             }
             if (listener != null) {

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptor.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptor.java
@@ -127,10 +127,10 @@ final class SandboxInterceptor extends GroovyInterceptor {
 
             // Allow calling closure variables from a script binding as methods
             if (receiver instanceof Script) {
-                Script s = (Script)receiver;
+                Script s = (Script) receiver;
                 if (s.getBinding().hasVariable(method)) {
                     Object var = s.getBinding().getVariable(method);
-                    if (!InvokerHelper.getMetaClass(var).respondsTo(var, "call", (Object[]) args).isEmpty()){
+                    if (!InvokerHelper.getMetaClass(var).respondsTo(var, "call", (Object[]) args).isEmpty()) {
                         return onMethodCall(invoker, var, "call", args);
                     }
                 }
@@ -139,7 +139,7 @@ final class SandboxInterceptor extends GroovyInterceptor {
             // if no matching method, look for catchAll "invokeMethod"
             try {
                 receiver.getClass().getMethod("invokeMethod", String.class, Object.class);
-                return onMethodCall(invoker,receiver,"invokeMethod",method,args);
+                return onMethodCall(invoker, receiver, "invokeMethod", method, args);
             } catch (NoSuchMethodException e) {
                 // fall through
             }
@@ -176,6 +176,8 @@ final class SandboxInterceptor extends GroovyInterceptor {
         if (m == null) {
             // TODO consider DefaultGroovyStaticMethods
             throw new RejectedAccessException("No such static method found: staticMethod " + EnumeratingWhitelist.getName(receiver) + " " + method + printArgumentTypes(args));
+        } else if (m.getDeclaringClass().equals(System.class) && m.getName().equals("exit")) {
+            throw StaticWhitelist.rejectStaticMethod(m);
         } else if (whitelist.permitsStaticMethod(m, args)) {
             return super.onStaticCall(invoker, receiver, method, args);
         } else {

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
@@ -54,16 +54,16 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * Whitelist based on a static file.
  */
 public final class StaticWhitelist extends EnumeratingWhitelist {
-    public static final String[] PERMANENTLY_BLACKLISTED_METHODS = {
+    private static final String[] PERMANENTLY_BLACKLISTED_METHODS = {
             "method java.lang.Runtime exit int",
             "method java.lang.Runtime halt int",
     };
 
-    public static final String[] PERMANENTLY_BLACKLISTED_STATIC_METHODS = {
+    private static final String[] PERMANENTLY_BLACKLISTED_STATIC_METHODS = {
             "staticMethod java.lang.System exit int",
     };
 
-    public static final String[] PERMANENTLY_BLACKLISTED_CONSTRUCTORS = new String[0];
+    private static final String[] PERMANENTLY_BLACKLISTED_CONSTRUCTORS = new String[0];
 
     final List<MethodSignature> methodSignatures = new ArrayList<MethodSignature>();
     final List<NewSignature> newSignatures = new ArrayList<NewSignature>();

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
@@ -54,6 +54,16 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * Whitelist based on a static file.
  */
 public final class StaticWhitelist extends EnumeratingWhitelist {
+    public static final String[] PERMANENTLY_BLACKLISTED_METHODS = {
+            "method java.lang.Runtime exit int",
+            "method java.lang.Runtime halt int",
+    };
+
+    public static final String[] PERMANENTLY_BLACKLISTED_STATIC_METHODS = {
+            "staticMethod java.lang.System exit int",
+    };
+
+    public static final String[] PERMANENTLY_BLACKLISTED_CONSTRUCTORS = new String[0];
 
     final List<MethodSignature> methodSignatures = new ArrayList<MethodSignature>();
     final List<NewSignature> newSignatures = new ArrayList<NewSignature>();
@@ -95,6 +105,57 @@ public final class StaticWhitelist extends EnumeratingWhitelist {
         return line;
     }
 
+    /**
+     * Returns true if the given method is permanently blacklisted in {@link #PERMANENTLY_BLACKLISTED_METHODS}
+     */
+    public static boolean isPermanentlyBlacklistedMethod(@Nonnull Method m) {
+        String signature = canonicalMethodSig(m);
+
+        for (String s : PERMANENTLY_BLACKLISTED_METHODS) {
+            if (s.equals(signature)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if the given method is permanently blacklisted in {@link #PERMANENTLY_BLACKLISTED_STATIC_METHODS}
+     */
+    public static boolean isPermanentlyBlacklistedStaticMethod(@Nonnull Method m) {
+        String signature = canonicalStaticMethodSig(m);
+
+        for (String s : PERMANENTLY_BLACKLISTED_STATIC_METHODS) {
+            if (s.equals(signature)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if the given constructor is permanently blacklisted in {@link #PERMANENTLY_BLACKLISTED_CONSTRUCTORS}
+     */
+    public static boolean isPermanentlyBlacklistedConstructor(@Nonnull Constructor c) {
+        String signature = canonicalConstructorSig(c);
+
+        for (String s : PERMANENTLY_BLACKLISTED_CONSTRUCTORS) {
+            if (s.equals(signature)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Parse a signature line into a {@link Signature}.
+     * @param line The signature string
+     * @return the equivalent {@link Signature}
+     * @throws IOException if the signature string could not be parsed.
+     */
     static Signature parse(String line) throws IOException {
         String[] toks = line.split(" ");
         if (toks[0].equals("method")) {
@@ -125,6 +186,31 @@ public final class StaticWhitelist extends EnumeratingWhitelist {
         } else {
             throw new IOException(line);
         }
+    }
+
+    /**
+     * Checks if the signature is permanently blacklisted, and so shouldn't show up in the pending approval list.
+     * @param signature the signature to check
+     * @return true if the signature is permanently blacklisted, false otherwise.
+     */
+    public static boolean isPermanentlyBlacklisted(String signature) {
+        for (String s : PERMANENTLY_BLACKLISTED_METHODS) {
+            if (s.equals(signature)) {
+                return true;
+            }
+        }
+        for (String s : PERMANENTLY_BLACKLISTED_STATIC_METHODS) {
+            if (s.equals(signature)) {
+                return true;
+            }
+        }
+        for (String s : PERMANENTLY_BLACKLISTED_CONSTRUCTORS) {
+            if (s.equals(signature)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void add(String line) throws IOException {

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -639,7 +639,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
     @Deprecated
     public synchronized RejectedAccessException accessRejected(@Nonnull RejectedAccessException x, @Nonnull ApprovalContext context) {
         String signature = x.getSignature();
-        if (signature != null && pendingSignatures.add(new PendingSignature(signature, x.isDangerous(), context))) {
+        if (signature != null && !signature.equals("staticMethod java.lang.System exit int") && pendingSignatures.add(new PendingSignature(signature, x.isDangerous(), context))) {
             try {
                 save();
             } catch (IOException x2) {

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -639,7 +639,7 @@ import org.kohsuke.stapler.bind.JavaScriptMethod;
     @Deprecated
     public synchronized RejectedAccessException accessRejected(@Nonnull RejectedAccessException x, @Nonnull ApprovalContext context) {
         String signature = x.getSignature();
-        if (signature != null && !signature.equals("staticMethod java.lang.System exit int") && pendingSignatures.add(new PendingSignature(signature, x.isDangerous(), context))) {
+        if (signature != null && pendingSignatures.add(new PendingSignature(signature, x.isDangerous(), context))) {
             try {
                 save();
             } catch (IOException x2) {

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -1164,9 +1164,17 @@ public class SandboxInterceptorTest {
     }
 
     @Test
-    public void alwaysRejectSystemExit() throws Exception {
+    public void alwaysRejectPermanentlyBlacklisted() throws Exception {
         assertRejected(new StaticWhitelist("staticMethod java.lang.System exit int"),
                 "staticMethod java.lang.System exit int",
                 "System.exit(1)");
+        assertRejected(new StaticWhitelist("method java.lang.Runtime exit int", "staticMethod java.lang.Runtime getRuntime"),
+                "method java.lang.Runtime exit int",
+                "Runtime r = Runtime.getRuntime();\n" +
+                        "r.exit(1)");
+        assertRejected(new StaticWhitelist("staticMethod java.lang.Runtime getRuntime", "method java.lang.Runtime halt int"),
+                "method java.lang.Runtime halt int",
+                "Runtime r = Runtime.getRuntime();\n" +
+                        "r.halt(1)");
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -1163,4 +1163,10 @@ public class SandboxInterceptorTest {
         }
     }
 
+    @Test
+    public void alwaysRejectSystemExit() throws Exception {
+        assertRejected(new StaticWhitelist("staticMethod java.lang.System exit int"),
+                "staticMethod java.lang.System exit int",
+                "System.exit(1)");
+    }
 }


### PR DESCRIPTION
There is never a valid reason for calling `System.exit(1)` in a
Jenkins Groovy script. Ever. So let's just permanently hack it into
always being rejected. Also, let's special case it in `ScriptApproval`
to not even show up as a pending signature.