### PR TITLE
[JENKINS-57299] Whitelist the following variants of drop* and take*:

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -425,6 +425,10 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.util.
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.util.Iterator groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods countBy java.util.Map groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods disjoint java.util.Collection java.util.Collection
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods drop java.lang.Iterable int
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods drop java.util.List int
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods dropRight java.lang.Iterable int
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods dropRight java.util.List int
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Iterable groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.lang.Object groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods each java.util.Collection groovy.lang.Closure
@@ -664,6 +668,9 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sum java.util.Coll
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods tail java.util.List
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods take java.lang.CharSequence int
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods take java.lang.Iterable int
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods take java.util.List int
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods takeRight java.lang.Iterable int
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods takeRight java.util.List int
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toBoolean java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toInteger java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toList boolean[]

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -346,7 +346,7 @@ public class SandboxInterceptorTest {
         }
     }
 
-    @Issue({"JENKINS-25119", "JENKINS-27725"})
+    @Issue({"JENKINS-25119", "JENKINS-27725", "JENKINS-57299"})
     @Test public void defaultGroovyMethods() throws Exception {
         assertRejected(new ProxyWhitelist(), "staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods toInteger java.lang.String", "'123'.toInteger();");
         assertEvaluate(new GenericWhitelist(), 123, "'123'.toInteger();");
@@ -360,6 +360,12 @@ public class SandboxInterceptorTest {
         assertEvaluate(new GenericWhitelist(), true, "'42'.number");
         // TODO should also cover set* methods, though these seem rare
         // TODO check DefaultGroovyStaticMethods also (though there are few useful & safe calls there)
+        // cover drop and dropRight methods:
+        assertEvaluate(new GenericWhitelist(), Arrays.asList(2, 3, 4), "[1, 2, 3, 4].drop(1)");
+        assertEvaluate(new GenericWhitelist(), Arrays.asList(1, 2, 3), "[1, 2, 3, 4].dropRight(1)");
+        // cover take and takeRight methods:
+        assertEvaluate(new GenericWhitelist(), Arrays.asList(1, 2), "[1, 2, 3, 4].take(2)");
+        assertEvaluate(new GenericWhitelist(), Arrays.asList(3, 4), "[1, 2, 3, 4].takeRight(2)");
     }
 
     @Test public void whitelistedIrrelevantInsideScript() throws Exception {


### PR DESCRIPTION
```
staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods drop java.lang.Iterable int
staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods drop java.util.List int
staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods dropRight java.lang.Iterable int
staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods dropRight java.util.List int
staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods take java.util.List int
staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods takeRight java.lang.Iterable int
staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods takeRight java.util.List int
```