### PR TITLE
Update parent pom to fix Javadoc errors on Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.40</version>
+    <version>3.43</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Fix the errors noticed in https://github.com/jenkinsci/script-security-plugin/pull/247. Explanation of the root cause is in https://github.com/jenkinsci/plugin-pom/pull/196.