### PR TITLE
JENKINS-57344: Whitelist requests for some java.io and other misc calls

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -40,25 +40,26 @@ new java.io.PrintWriter java.io.Writer
 method java.io.PrintWriter print java.lang.Object
 method java.io.PrintWriter print java.lang.String
 
+method java.io.Reader read
+method java.io.Reader read char[]
+method java.io.Reader read char[] int int
+method java.io.Reader reset
+method java.io.Reader skip long
+
 # Useful general stuff:
 new java.io.StringReader java.lang.String
-method java.io.StringReader close
-method java.io.StringReader read
-method java.io.StringReader read char[]
-method java.io.StringReader read char[] int int
-method java.io.StringReader reset
-method java.io.StringReader skip int
 new java.io.StringWriter
-method java.io.StringWriter append char
-method java.io.StringWriter append java.lang.CharSequence
-method java.io.StringWriter append java.lang.CharSequence int int
-method java.io.StringWriter close
-method java.io.StringWriter flush
-method java.io.StringWriter write char[]
-method java.io.StringWriter write char[] int int
-method java.io.StringWriter int
-method java.io.StringWriter write java.lang.String
-method java.io.StringWriter write java.lang.String int int
+
+method java.io.Writer write char[]
+method java.io.Writer write char[] int int
+method java.io.Writer write int
+method java.io.Writer write java.lang.String
+method java.io.Writer write java.lang.String int int
+
+method java.lang.Appendable append char
+method java.lang.Appendable append java.lang.CharSequence
+method java.lang.Appendable append java.lang.CharSequence int int
+method java.lang.AutoCloseable close
 new java.lang.Boolean java.lang.String
 staticMethod java.lang.Boolean parseBoolean java.lang.String
 staticMethod java.lang.Boolean valueOf boolean
@@ -73,6 +74,7 @@ new java.lang.Enum java.lang.String int
 method java.lang.Enum name
 method java.lang.Enum ordinal
 new java.lang.Exception java.lang.String
+method java.lang.Flushable flush
 staticField java.lang.Integer MAX_VALUE
 # could add valueOf, though currently the staticField’s need to be whitelisted, which is the more likely use case
 staticMethod java.lang.Integer parseInt java.lang.String
@@ -301,9 +303,9 @@ new java.util.Date
 new java.util.Date long
 new java.util.HashSet
 new java.util.HashSet java.util.Collection
-new java.util.LinkedHashSet
 method java.util.Iterator hasNext
 method java.util.Iterator next
+new java.util.LinkedHashSet
 method java.util.List add int java.lang.Object
 method java.util.List get int
 method java.util.List remove int

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -364,6 +364,7 @@ method java.util.concurrent.Callable call
 staticField java.util.concurrent.TimeUnit HOURS
 staticField java.util.concurrent.TimeUnit MINUTES
 method java.util.regex.MatchResult group int
+method java.util.regex.Matcher find
 method java.util.regex.Matcher group java.lang.String
 method java.util.regex.Matcher matches
 method java.util.regex.Matcher replaceAll java.lang.String
@@ -498,6 +499,7 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods first java.util.Li
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods flatten java.util.Collection groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods flatten java.util.List
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods get java.util.Map java.lang.Object java.lang.Object
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.lang.Object[] groovy.lang.Range
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.lang.String groovy.lang.IntRange
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.lang.String groovy.lang.Range
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.lang.String int

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -34,13 +34,31 @@ method groovy.lang.Closure setResolveStrategy int
 method groovy.lang.GString plus java.lang.String
 method groovy.lang.Script getBinding
 
+# Useful to show stacktrace to the user.
+new java.io.PrintWriter java.io.Writer
 # Needed for Groovy Templates to emit output:
 method java.io.PrintWriter print java.lang.Object
 method java.io.PrintWriter print java.lang.String
 
 # Useful general stuff:
 new java.io.StringReader java.lang.String
+method java.io.StringReader close
+method java.io.StringReader read
+method java.io.StringReader read char[]
+method java.io.StringReader read char[] int int
+method java.io.StringReader reset
+method java.io.StringReader skip int
 new java.io.StringWriter
+method java.io.StringWriter append char
+method java.io.StringWriter append java.lang.CharSequence
+method java.io.StringWriter append java.lang.CharSequence int int
+method java.io.StringWriter close
+method java.io.StringWriter flush
+method java.io.StringWriter write char[]
+method java.io.StringWriter write char[] int int
+method java.io.StringWriter int
+method java.io.StringWriter write java.lang.String
+method java.io.StringWriter write java.lang.String int int
 new java.lang.Boolean java.lang.String
 staticMethod java.lang.Boolean parseBoolean java.lang.String
 staticMethod java.lang.Boolean valueOf boolean
@@ -283,8 +301,10 @@ new java.util.Date
 new java.util.Date long
 new java.util.HashSet
 new java.util.HashSet java.util.Collection
+new java.util.LinkedHashSet
 method java.util.Iterator hasNext
 method java.util.Iterator next
+method java.util.List add int java.lang.Object
 method java.util.List get int
 method java.util.List remove int
 method java.util.List subList int int
@@ -616,6 +636,7 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods putAt java.util.Ma
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods removeAll java.util.Collection groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods retainAll java.util.Collection groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverse java.util.Iterator
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverse java.util.List
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverseEach java.lang.Object[] groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverseEach java.util.List groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods reverseEach java.util.Map groovy.lang.Closure


### PR DESCRIPTION
This PR whitelists a few java.io reader and writer methods that are useful on filters (wrapper readers and writers). It also whitelists a few list operations 