### PR TITLE
SandboxResolvingClassLoader.parentClassCache could leak loaders

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyMemoryLeakTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyMemoryLeakTest.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
 
 import groovy.lang.MetaClass;
 import hudson.model.FreeStyleProject;
-import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 import org.codehaus.groovy.reflection.ClassInfo;
 import org.junit.*;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -42,8 +41,6 @@ public class GroovyMemoryLeakTest {
 
     @Test
     public void loaderReleased() throws Exception {
-        Assume.assumeTrue(isRunningOnJDK8());
-
         FreeStyleProject p = r.jenkins.createProject(FreeStyleProject.class, "p");
         p.getPublishersList().add(new TestGroovyRecorder(
                 new SecureGroovyScript(GroovyMemoryLeakTest.class.getName()+".register(this)", false, null)));
@@ -63,7 +60,4 @@ public class GroovyMemoryLeakTest {
         }
     }
 
-    private boolean isRunningOnJDK8() {
-        return JavaSpecificationVersion.forCurrentJVM().isOlderThanOrEqualTo(JavaSpecificationVersion.JAVA_8);
-    }
 }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyMemoryLeakTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyMemoryLeakTest.java
@@ -1,21 +1,26 @@
 package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
 
 import groovy.lang.MetaClass;
+import hudson.PluginManager;
 import hudson.model.FreeStyleProject;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import org.apache.commons.text.CharacterPredicates;
 import org.codehaus.groovy.reflection.ClassInfo;
-import org.junit.*;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ClasspathEntry;
+import org.junit.After;
+import static org.junit.Assert.*;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.LoggerRule;
 import org.jvnet.hudson.test.MemoryAssert;
-
-import java.lang.ref.WeakReference;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
-
-import static org.junit.Assert.assertFalse;
 
 /**
  * Tests for memory leak cleanup successfully purging the most common memory leak.
@@ -34,16 +39,19 @@ public class GroovyMemoryLeakTest {
     private static final List<WeakReference<ClassLoader>> LOADERS = new ArrayList<>();
 
     public static void register(Object o) {
-        ClassLoader loader = o.getClass().getClassLoader();
-        System.err.println("registering " + o + " from " + loader);
-        LOADERS.add(new WeakReference<>(loader));
+        System.err.println("registering " + o);
+        for (ClassLoader loader = o.getClass().getClassLoader(); !(loader instanceof PluginManager.UberClassLoader); loader = loader.getParent()) {
+            System.err.println("…from " + loader);
+            LOADERS.add(new WeakReference<>(loader));
+        }
     }
 
     @Test
     public void loaderReleased() throws Exception {
         FreeStyleProject p = r.jenkins.createProject(FreeStyleProject.class, "p");
+        String cp = CharacterPredicates.class.getProtectionDomain().getCodeSource().getLocation().toString(); // some JAR
         p.getPublishersList().add(new TestGroovyRecorder(
-                new SecureGroovyScript(GroovyMemoryLeakTest.class.getName()+".register(this)", false, null)));
+            new SecureGroovyScript(GroovyMemoryLeakTest.class.getName()+".register(this)", false, Collections.singletonList(new ClasspathEntry(cp)))));
         r.buildAndAssertSuccess(p);
 
         assertFalse(LOADERS.isEmpty());


### PR DESCRIPTION
Tracked down a memory leak in `SandboxResolvingClassLoader.parentClassCache`. Turns out its use of `weakKeys` did not work at all. The existing test did not catch this, since the `parentLoader` in that case is an `UberClassLoader`, which you would not expect to be collected anyway. But if you have a nonempty `SecureGroovyScript.classpath`, for example, then the parent loader was a new `URLClassLoader`, and this never got released. Thus any classes actually loaded from a classpath JAR would never be released, leading to increased heap/metaspace on each build.

(Not sure if there is a case where this could affect Pipeline; the observed case involved the `uno-choice` plugin and build parameters on a freestyle project. https://github.com/jenkinsci/jenkins/pull/4035 also came out of this case; [CloudBees-internal issue](https://cloudbees.atlassian.net/browse/CPLT2-5589).)

Subsumes #251. Merge conflict with #160, which would be a somewhat bigger change.