### PR TITLE
PoC of JDK-6389107 workaround

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/ClassLoaderCache.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/ClassLoaderCache.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
+
+/**
+ * A cache keyed by {@link ClassLoader} in which values may safely refer to keys (including their loaded classes) without introducing memory leaks.
+ * @see <a href="https://bugs.openjdk.java.net/browse/JDK-6389107">JDK-6389107</a>
+ */
+@SuppressWarnings("unchecked")
+final class ClassLoaderCache<V> {
+
+    private static final Object HACK_KEY = ClassLoaderCache.class.getName() + "$$__$$"; // not a valid package name
+
+    /**
+     * Need a {@link Map}-valued instance field in {@link ClassLoader} which is never null and whose entries are never enumerated.
+     * We will stash a mistyped value in there under a special {@link #HACK_KEY}.
+     * This is nothing more than a way to get a {@link ClassLoader} to strongly refer to a value of our choice.
+     */
+    private static @CheckForNull Map<Object, Object> hack(ClassLoader loader) {
+        try {
+            Field f = ClassLoader.class.getDeclaredField("package2certs");
+            f.setAccessible(true);
+            return (Map) f.get(loader);
+        } catch (Exception x) {
+            // TODO https://github.com/eclipse/openj9/blob/master/jcl/src/java.base/share/classes/java/lang/ClassLoader.java has rather different fields from OpenJDK’s
+            Logger.getLogger(ClassLoaderCache.class.getName()).log(Level.WARNING, "unsupported JRE, maybe J9?", x);
+            return null;
+        }
+    }
+
+    private final Function<ClassLoader, V> func;
+
+    ClassLoaderCache(Function<ClassLoader, V> func) {
+        this.func = func;
+    }
+
+    V get(ClassLoader key) {
+        Map<Object, Object> hack = hack(key);
+        if (hack == null) {
+            // disable cache in this case; or could fall back to a WeakHashMap<ClassLoader, SoftReference<V>>
+            return func.apply(key);
+        }
+        Map<ClassLoaderCache<?>, Object> caches;
+        synchronized (hack) {
+            caches = (Map<ClassLoaderCache<?>, Object>) hack.computeIfAbsent(HACK_KEY, hackKey -> new WeakHashMap<ClassLoaderCache<?>, Object>());
+        }
+        synchronized (caches) {
+            return (V) caches.computeIfAbsent(this, _this -> func.apply(key));
+        }
+    }
+
+    /**
+     * A cache keyed by {@link Class} in which values may safely refer to keys (including their defining loaders) without introducing memory leaks.
+     */
+    static final class ClassCache<V> {
+
+        private final Function<Class<?>, V> func;
+        private final ClassLoaderCache<Map<Class<?>, V>> delegate;
+
+        ClassCache(Function<Class<?>, V> func) {
+            this.func = func;
+            delegate = new ClassLoaderCache<>(loader -> new ConcurrentHashMap<>());
+        }
+
+        V get(Class<?> key) {
+            return delegate.get(key.getClassLoader()).computeIfAbsent(key, func);
+        }
+
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoader.java
@@ -1,16 +1,12 @@
 package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
 
 import com.google.common.base.Optional;
-import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import groovy.lang.GroovyShell;
 import java.net.URL;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
+import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -26,37 +22,26 @@ class SandboxResolvingClassLoader extends ClassLoader {
     
     private static final Logger LOGGER = Logger.getLogger(SandboxResolvingClassLoader.class.getName());
 
-    private static final LoadingCache<ClassLoader, Cache<String, Class<?>>> parentClassCache = makeParentCache(true);
+    private static final ClassLoaderCache<LoadingCache<String, Optional<Class<?>>>> parentClassCache = makeParentCache((parentLoader, name) -> {
+        try {
+            return Optional.of(parentLoader.loadClass(name));
+        } catch (ClassNotFoundException x) {
+            return Optional.absent();
+        }
+    });
 
-    private static final LoadingCache<ClassLoader, Cache<String, Optional<URL>>> parentResourceCache = makeParentCache(false);
+    private static final ClassLoaderCache<LoadingCache<String, Optional<URL>>> parentResourceCache = makeParentCache((parentLoader, name) -> Optional.fromNullable(parentLoader.getResource(name)));
 
     SandboxResolvingClassLoader(ClassLoader parent) {
         super(parent);
     }
 
-    /**
-     * Marker value for a {@link ClassNotFoundException} negative cache hit.
-     * Cannot use null, since the cache API does not permit null values.
-     * Cannot use {@code Optional<Class<?>>} since weak values would mean this is always collected.
-     * This value is non-null, not a legitimate return value
-     * (no script should be trying to load this implementation detail), and strongly held.
-     */
-    private static final Class<?> CLASS_NOT_FOUND = Unused.class;
-    private static final class Unused {}
-
     @Override protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
         if (name.startsWith("org.kohsuke.groovy.sandbox.")) {
             return this.getClass().getClassLoader().loadClass(name);
         } else {
-            ClassLoader parentLoader = getParent();
-            Class<?> c = load(parentClassCache, name, parentLoader, () -> {
-                try {
-                    return parentLoader.loadClass(name);
-                } catch (ClassNotFoundException x) {
-                    return CLASS_NOT_FOUND;
-                }
-            });
-            if (c != CLASS_NOT_FOUND) {
+            Class<?> c = parentClassCache.get(getParent()).getUnchecked(name).orNull();
+            if (c != null) {
                 if (resolve) {
                     super.resolveClass(c);
                 }
@@ -72,42 +57,29 @@ class SandboxResolvingClassLoader extends ClassLoader {
     }
 
     @Override public URL getResource(String name) {
-        ClassLoader parentLoader = getParent();
-        return load(parentResourceCache, name, parentLoader, () -> Optional.fromNullable(parentLoader.getResource(name))).orNull();
+        return parentResourceCache.get(getParent()).getUnchecked(name).orNull();
     }
 
-    // We cannot have the inner cache be a LoadingCache and just use .get(name), since then the values of the outer cache would strongly refer to the keys.
-    private static <T> T load(LoadingCache<ClassLoader, Cache<String, T>> cache, String name, ClassLoader parentLoader, Supplier<T> supplier) {
-        try {
-            return cache.getUnchecked(parentLoader).get(name, () -> {
-                Thread t = Thread.currentThread();
-                String origName = t.getName();
-                t.setName(origName + " loading " + name);
-                long start = System.nanoTime(); // http://stackoverflow.com/q/19052316/12916
-                try {
-                    return supplier.get();
-                } finally {
-                    t.setName(origName);
-                    long ms = (System.nanoTime() - start) / 1000000;
-                    if (ms > 1000) {
-                        LOGGER.log(Level.INFO, "took {0}ms to load/not load {1} from {2}", new Object[] {ms, name, parentLoader});
+    private static <T> ClassLoaderCache<LoadingCache<String, T>> makeParentCache(BiFunction<ClassLoader, String, T> func) {
+        // TODO expire cache if new plugins are installed
+        return new ClassLoaderCache<>(parentLoader -> {
+            return CacheBuilder.newBuilder().build(new CacheLoader<String, T>() {
+                @Override public T load(String name) throws Exception {
+                    Thread t = Thread.currentThread();
+                    String origName = t.getName();
+                    t.setName(origName + " loading " + name);
+                    long start = System.nanoTime(); // http://stackoverflow.com/q/19052316/12916
+                    try {
+                        return func.apply(parentLoader, name);
+                    } finally {
+                        t.setName(origName);
+                        long ms = (System.nanoTime() - start) / 1000000;
+                        if (ms > 1000) {
+                            LOGGER.log(Level.INFO, "took {0}ms to load/not load {1} from {2}", new Object[] {ms, name, parentLoader});
+                        }
                     }
                 }
             });
-        } catch (ExecutionException x) {
-            throw new UncheckedExecutionException(x); // should not be possible anyway
-        }
-    }
-
-    private static <T> LoadingCache<ClassLoader, Cache<String, T>> makeParentCache(boolean weakValues) {
-        CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder().weakKeys();
-        if (weakValues) {
-            builder = builder.weakValues();
-        }
-        return builder.build(new CacheLoader<ClassLoader, Cache<String, T>>() {
-            @Override public Cache<String, T> load(ClassLoader parentLoader) {
-                return CacheBuilder.newBuilder()./* allow new plugins to be used, and clean up memory */expireAfterWrite(15, TimeUnit.MINUTES).build();
-            }
         });
     }
 


### PR DESCRIPTION
Demonstrating that the special case of a `ClassLoader`- (or `Class-`) keyed cache can be handled despite [JDK-6389107](https://bugs.openjdk.java.net/browse/JDK-6389107) if you are willing to poke around a tiny bit in Java internals.

I am not inclined to merge this as `SandboxResolvingClassLoader.parentClassCache` from #252 / #253 can do without (weakly holding values is OK for that use case), but wanted to record this in case we come across another situation where we are otherwise stuck with `SoftReference`d values, manual cache cleanup (e.g. using `AutoCloseable`), or other undesirable workarounds. Certainly Groovy itself and `java.beans.Introspector` could use a utility like this in numerous places (and save us from the `cleanUpHeap` hacks).

No unit tests at this point, just tested implicitly via `GroovyMemoryLeakTest` etc.