### PR TITLE
[JENKINS-24650] Enable syntax highlighting for groovy scripts.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript/JENKINS-15604.js
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript/JENKINS-15604.js
@@ -1,5 +1,0 @@
-// https://issues.jenkins-ci.org/browse/JENKINS-15604 workaround:
-function cmChange(editor, change) {
-    editor.save();
-    $$('.validated').each(function (e) {e.onchange();});
-}

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript/config.jelly
@@ -26,9 +26,8 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry field="script" title="${%Groovy Script}">
-        <!-- TODO <st:adjunct includes="org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.JENKINS-15604"/> -->
-        <!-- TODO https://github.com/stapler/stapler-adjunct-codemirror/issues/1 means no true Groovy support -->
-        <f:textarea checkMethod="post"/> <!-- TODO codemirror-mode="clike" codemirror-config="'onBlur': cmChange" -->
+        <!-- The })// at the end of codemirror-config is a hack to work around Jenkins core replacing any onBlur we provide (see textarea.js) -->
+        <f:textarea checkMethod="post" codemirror-mode="clike" codemirror-config="mode: 'text/x-groovy', lineNumbers: true, matchBrackets: true, onBlur: function(editor){editor.save();editor.getTextArea().onchange();} })//" />
     </f:entry>
     <f:entry field="sandbox">
         <f:checkbox title="${%Use Groovy Sandbox}" default="${!h.hasPermission(app.RUN_SCRIPTS)}" />


### PR DESCRIPTION
Enable groovy syntax highlighting for plugins that use the editor provided by script-security (such as the groovy plugin and the  groovy postbuild plugin).

Requested in [JENKINS-24650](https://issues.jenkins-ci.org/browse/JENKINS-24650).

See also: https://github.com/jenkinsci/jenkins/pull/4046