### PR TITLE
JENKINS-58799: Whitelisting a few collection related methods

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -32,6 +32,12 @@ method groovy.lang.Closure ncurry int java.lang.Object[]
 method groovy.lang.Closure setDelegate java.lang.Object
 method groovy.lang.Closure setResolveStrategy int
 method groovy.lang.GString plus java.lang.String
+method groovy.lang.NumberRange by int
+method groovy.lang.NumberRange getStepSize
+method groovy.lang.Range getFrom
+method groovy.lang.Range getTo
+method groovy.lang.Range step int
+method groovy.lang.Range step int groovy.lang.Closure
 method groovy.lang.Script getBinding
 
 # Useful to show stacktrace to the user.
@@ -332,6 +338,7 @@ staticField java.util.Locale UK
 staticField java.util.Locale US
 method java.util.Map clear
 method java.util.Map containsKey java.lang.Object
+method java.util.Map containsValue java.lang.Object
 method java.util.Map entrySet
 method java.util.Map get java.lang.Object
 method java.util.Map getOrDefault java.lang.Object java.lang.Object
@@ -503,6 +510,7 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods flatten java.util.
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods flatten java.util.List
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods get java.util.Map java.lang.Object java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.lang.Object[] groovy.lang.Range
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.lang.Object[] java.util.Collection
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.lang.String groovy.lang.IntRange
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.lang.String groovy.lang.Range
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods getAt java.lang.String int
@@ -577,6 +585,8 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.Co
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.List java.lang.Iterable
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.List java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.List java.util.Collection
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.List removeAt int
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.List removeLast
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.Map java.util.Map
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.Set java.lang.Iterable
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.Set java.lang.Object


### PR DESCRIPTION
This PR whitelists mainly a few collection methods that will enable access using range. It also includes a few Groovy collection enhancements in the list.