### PR TITLE
[JENKINS-59587] Use weakValues on the inner caches in SandboxResolvingClassLoader.parentClassCache instead of on the outer cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,18 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <reuseForks>false</reuseForks>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.kohsuke</groupId>

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoader.java
@@ -23,9 +23,9 @@ class SandboxResolvingClassLoader extends ClassLoader {
 
     private static final Logger LOGGER = Logger.getLogger(SandboxResolvingClassLoader.class.getName());
 
-    private static final LoadingCache<ClassLoader, Cache<String, Class<?>>> parentClassCache = makeParentCache(true);
+    static final LoadingCache<ClassLoader, Cache<String, Class<?>>> parentClassCache = makeParentCache(true);
 
-    private static final LoadingCache<ClassLoader, Cache<String, Optional<URL>>> parentResourceCache = makeParentCache(false);
+    static final LoadingCache<ClassLoader, Cache<String, Optional<URL>>> parentResourceCache = makeParentCache(false);
 
     SandboxResolvingClassLoader(ClassLoader parent) {
         super(parent);
@@ -38,7 +38,7 @@ class SandboxResolvingClassLoader extends ClassLoader {
      * This value is non-null, not a legitimate return value
      * (no script should be trying to load this implementation detail), and strongly held.
      */
-    private static final Class<?> CLASS_NOT_FOUND = Unused.class;
+    static final Class<?> CLASS_NOT_FOUND = Unused.class;
     private static final class Unused {}
 
     @Override protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
@@ -93,12 +93,18 @@ class SandboxResolvingClassLoader extends ClassLoader {
         });
     }
 
-    private static <T> LoadingCache<ClassLoader, Cache<String, T>> makeParentCache(boolean weakValues) {
-        Caffeine<Object, Object> builder = Caffeine.newBuilder().weakKeys();
-        if (weakValues) {
-            builder = builder.weakValues();
+    private static <T> LoadingCache<ClassLoader, Cache<String, T>> makeParentCache(boolean weakValuesInnerCache) {
+        // The outer cache has weak keys, so that we do not leak class loaders, but strong values, because the
+        // inner caches are only referenced by the outer cache internally.
+        Caffeine<Object, Object> outerBuilder = Caffeine.newBuilder().weakKeys();
+        // The inner cache has strong keys, since they are just strings, and expires entries 15 minutes after they are
+        // added to the cache (TODO: should we use expireAfterAccess instead?). The values for the inner cache may
+        // be weak if needed, for example parentClassCache uses weak values to avoid leaking classes and their loaders.
+        Caffeine<Object, Object> innerBuilder = Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(15));
+        if (weakValuesInnerCache) {
+            innerBuilder.weakValues();
         }
 
-        return builder.build(parentLoader -> Caffeine.newBuilder()./* allow new plugins to be used, and clean up memory */expireAfterWrite(Duration.ofMinutes(15)).build());
+        return outerBuilder.build(parentLoader -> innerBuilder.build());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoader.java
@@ -98,8 +98,10 @@ class SandboxResolvingClassLoader extends ClassLoader {
         // inner caches are only referenced by the outer cache internally.
         Caffeine<Object, Object> outerBuilder = Caffeine.newBuilder().weakKeys();
         // The inner cache has strong keys, since they are just strings, and expires entries 15 minutes after they are
-        // added to the cache (TODO: should we use expireAfterAccess instead?). The values for the inner cache may
-        // be weak if needed, for example parentClassCache uses weak values to avoid leaking classes and their loaders.
+        // added to the cache, so that classes defined by dynamically installed plugins become available even if there
+        // were negative cache hits prior to the installation (ideally this would be done with a listener). The values
+        // for the inner cache may be weak if needed, for example parentClassCache uses weak values to avoid leaking
+        // classes and their loaders.
         Caffeine<Object, Object> innerBuilder = Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(15));
         if (weakValuesInnerCache) {
             innerBuilder.weakValues();

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoader.java
@@ -96,13 +96,13 @@ class SandboxResolvingClassLoader extends ClassLoader {
     private static <T> LoadingCache<ClassLoader, Cache<String, T>> makeParentCache(boolean weakValuesInnerCache) {
         // The outer cache has weak keys, so that we do not leak class loaders, but strong values, because the
         // inner caches are only referenced by the outer cache internally.
-        Caffeine<Object, Object> outerBuilder = Caffeine.newBuilder().weakKeys();
+        Caffeine<Object, Object> outerBuilder = Caffeine.newBuilder().recordStats().weakKeys();
         // The inner cache has strong keys, since they are just strings, and expires entries 15 minutes after they are
         // added to the cache, so that classes defined by dynamically installed plugins become available even if there
         // were negative cache hits prior to the installation (ideally this would be done with a listener). The values
         // for the inner cache may be weak if needed, for example parentClassCache uses weak values to avoid leaking
         // classes and their loaders.
-        Caffeine<Object, Object> innerBuilder = Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(15));
+        Caffeine<Object, Object> innerBuilder = Caffeine.newBuilder().recordStats().expireAfterWrite(Duration.ofMinutes(15));
         if (weakValuesInnerCache) {
             innerBuilder.weakValues();
         }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoaderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoaderTest.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader.CLASS_NOT_FOUND;
+import static org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader.parentClassCache;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class SandboxResolvingClassLoaderTest {
+
+    private final ClassLoader parentLoader = SandboxResolvingClassLoaderTest.class.getClassLoader();
+    private final SandboxResolvingClassLoader loader = new SandboxResolvingClassLoader(parentLoader);
+
+    @Test public void classCacheDoesNotHoldClassValuesTooWeakly() throws Exception {
+        // Load a class that does exist.
+        assertThat(loader.loadClass("java.lang.String", false), equalTo(String.class));
+        // Load a class that does not exist.
+        try {
+            loader.loadClass("this.does.not.Exist", false);
+            fail("Class should not exist");
+        } catch (ClassNotFoundException e) {
+            assertThat(e.getMessage(), containsString("this.does.not.Exist"));
+        }
+        // The result of both of the class loading attempts should exist in the cache.
+        assertThat(parentClassCache.get(parentLoader).getIfPresent("java.lang.String"), equalTo(String.class));
+        assertThat(parentClassCache.get(parentLoader).getIfPresent("this.does.not.Exist"), equalTo(CLASS_NOT_FOUND));
+        // Make sure that both of the entries are still in the cache after a GC.
+        System.gc();
+        assertThat(parentClassCache.get(parentLoader).getIfPresent("java.lang.String"), equalTo(String.class));
+        assertThat(parentClassCache.get(parentLoader).getIfPresent("this.does.not.Exist"), equalTo(CLASS_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
See [JENKINS-59587](https://issues.jenkins-ci.org/browse/JENKINS-59587).

While investigating a user-reported performance issue, I noticed among other things that their Pipelines were spending a ton of time blocked waiting to acquire the lock for `PluginManager$UberClassLoader` while loading classes in `SandboxResolvingClassLoader`. This was a little surprising, because this user has a single shared library that is used by all of their Pipeline builds, so I would've thought that they would have a very high cache hit ratio, but that did not seem to be the case.

Looking into it, I noticed that in `SandboxResolvingClassLoader`, we were using `weakValues` on `parentClassCache` itself as of #252. This didn't make sense to me, because the values of `parentClassCache` are `Cache<String, Class<?>>`, and from what I can tell, these caches are only referenced internally by `parentClassCache`, which meant that the inner caches would always be removed when the garbage collector runs, making the cache not very useful when Jenkins is under significant memory pressure (which was definitely case for this user for other reasons).

This PR switches to using `weakValues` on `parentClassCache`'s inner caches, rather than `parentClassCache` itself. This way, the classes referenced by the inner cache are still only weakly referenced, so that their class loader, which may itself be a key of `parentClassCache`, is still able to be garbage collected. Looking into it some more, I think #252 was doing this already before 36d3b3a2a5b8561079cdccde53db85000dd40979, but that commit changed the semantics from `Cache<ClassLoader, Cache<String, Optional<WeakReference<Class<?>>>>>` to `Cache<ClassLoader, WeakReference<Cache<String, Optional<Class<?>>>>>`, and unfortunately we didn't notice that change in semantics during review.

I added a basic smoke test that fails if you revert the changes in `src/main`. `GroovyMemoryLeakTest` still passes, but I'm not sure what other testing would be useful to make sure this doesn't cause any regressions.