### PR TITLE
Remove useless whitelist entries, fix typo, and improve tests

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -32,14 +32,13 @@ method groovy.lang.Closure ncurry int java.lang.Object[]
 method groovy.lang.Closure setDelegate java.lang.Object
 method groovy.lang.Closure setResolveStrategy int
 method groovy.lang.GString plus java.lang.String
-method groovy.lang.NumberRange by int
-method groovy.lang.NumberRange getStepSize
 method groovy.lang.Range getFrom
 method groovy.lang.Range getTo
 method groovy.lang.Range step int
 method groovy.lang.Range step int groovy.lang.Closure
 method groovy.lang.Script getBinding
 
+method java.io.Flushable flush
 # Useful to show stacktrace to the user.
 new java.io.PrintWriter java.io.Writer
 # Needed for Groovy Templates to emit output:
@@ -80,7 +79,6 @@ new java.lang.Enum java.lang.String int
 method java.lang.Enum name
 method java.lang.Enum ordinal
 new java.lang.Exception java.lang.String
-method java.lang.Flushable flush
 staticField java.lang.Integer MAX_VALUE
 # could add valueOf, though currently the staticField’s need to be whitelisted, which is the more likely use case
 staticMethod java.lang.Integer parseInt java.lang.String
@@ -587,8 +585,6 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.Co
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.List java.lang.Iterable
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.List java.lang.Object
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.List java.util.Collection
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.List removeAt int
-staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.List removeLast
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.Map java.util.Map
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.Set java.lang.Iterable
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods minus java.util.Set java.lang.Object

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
@@ -102,7 +102,7 @@ public class StaticWhitelistTest {
                 assertTrue(sig + " does not exist (or is an override)", sig.exists());
             } catch (ClassNotFoundException x) {
                 if (!KNOWN_GOOD_SIGNATURES.contains(sig)) {
-                    throw x;
+                    throw new Exception("Unable to verify existence of " + sig, x);
                 }
             }
         }


### PR DESCRIPTION
#249 and #261 had some problems. `NumberRange` does not exist in Groovy 2.4.x, which is what Jenkins is using, the `DefaultGroovyMethods.minus` entries are malformed because of `removeAt` and `removeLast`, and `Flushable` is in the `java.io` package, not `java.lang`.

CC @haridsv 