### PR TITLE
[PoC] Switch from manually loaded to asynchronously loaded inner caches

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoaderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoaderTest.java
@@ -25,11 +25,17 @@
 package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
 
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import java.lang.management.LockInfo;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.concurrent.CountDownLatch;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader.CLASS_NOT_FOUND;
 import static org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader.parentClassCache;
 import static org.junit.Assert.assertThat;
@@ -37,31 +43,97 @@ import static org.junit.Assert.fail;
 
 public class SandboxResolvingClassLoaderTest {
 
-    private final ClassLoader parentLoader = SandboxResolvingClassLoaderTest.class.getClassLoader();
-    private final SandboxResolvingClassLoader loader = new SandboxResolvingClassLoader(parentLoader);
-
     @Issue("JENKINS-59587")
     @Test public void classCacheDoesNotHoldClassValuesTooWeakly() throws Exception {
+        ClassLoader parentLoader = SandboxResolvingClassLoaderTest.class.getClassLoader();
+        SandboxResolvingClassLoader loader = new SandboxResolvingClassLoader(parentLoader);
         // Load a class that does exist.
-        assertThat(loader.loadClass("java.lang.String", false), equalTo(String.class));
+        assertThat(loader.loadClass("java.lang.String"), equalTo(String.class));
         // Load a class that does not exist.
         try {
-            loader.loadClass("this.does.not.Exist", false);
+            loader.loadClass("this.does.not.Exist");
             fail("Class should not exist");
         } catch (ClassNotFoundException e) {
             assertThat(e.getMessage(), containsString("this.does.not.Exist"));
         }
         // The result of both of the class loading attempts should exist in the cache.
-        assertThat(parentClassCache.get(parentLoader).getIfPresent("java.lang.String"), equalTo(String.class));
-        assertThat(parentClassCache.get(parentLoader).getIfPresent("this.does.not.Exist"), equalTo(CLASS_NOT_FOUND));
+        assertThat(loadClass(parentLoader, "java.lang.String"), equalTo(String.class));
+        assertThat(loadClass(parentLoader, "this.does.not.Exist"), equalTo(CLASS_NOT_FOUND));
         // Make sure that both of the entries are still in the cache after a GC.
         System.gc();
-        assertThat(parentClassCache.get(parentLoader).getIfPresent("java.lang.String"), equalTo(String.class));
-        assertThat(parentClassCache.get(parentLoader).getIfPresent("this.does.not.Exist"), equalTo(CLASS_NOT_FOUND));
-        CacheStats stats = parentClassCache.get(parentLoader).stats();
+        assertThat(loadClass(parentLoader, "java.lang.String"), equalTo(String.class));
+        assertThat(loadClass(parentLoader, "this.does.not.Exist"), equalTo(CLASS_NOT_FOUND));
+        CacheStats stats = parentClassCache.get(parentLoader).synchronous().stats();
         // Before the fix for JENKINS-59587, the original inner cache was removed after the call to `System.gc()`, so
         // the miss count was 2 and the hit count was 0.
         assertThat(stats.missCount(), equalTo(2L)); // The two calls to `loadClass()`
         assertThat(stats.hitCount(), equalTo(4L)); // The four calls to `getIfPresent()`
+    }
+
+    @Test public void classCacheOnlyBlocksAtLoadClass() throws Exception {
+        ControlledBlockingClassLoader parentLoader = new ControlledBlockingClassLoader(SandboxResolvingClassLoaderTest.class.getClassLoader());
+        // Load a bunch of classes using the same blocking parent class loader so they share an inner cache. While we
+        // expect to see all of the threads blocked inside of `ControlledBlockingClassLoader.loadClass` on the latch,
+        // before the fix for JENKINS-XXX, some threads end up blocked earlier on a call to `ConcurrentHashMap.compute`
+        // on the map backing the cache, waiting to lock a `ConcurrentHashMap$ReservationNode` locked by one of the other
+        // threads blocked in `ControlledBlockingClassLoader.loadClass`. The default cache size is 16, so we load 16 + 32
+        // values so that we fill the initial table to capacity, and then fill the resized table, to make it more likely
+        // to trigger the bug.
+        for (int i = 0; i < 16 + 32; i++) {
+            final int j = i;
+            SandboxResolvingClassLoader loader = new SandboxResolvingClassLoader(parentLoader);
+            runInNewThread("blocker-" + j, () -> loader.loadClass("com.foo.Bar"+j));
+        }
+        Thread.sleep(500); // Try to wait for all of the futures to be inserted into the map.
+        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+        long[] threadIds = threadBean.getAllThreadIds();
+        for (long threadId : threadIds) {
+            ThreadInfo threadInfo = threadBean.getThreadInfo(threadId, 16);
+            if (threadInfo != null && threadInfo.getThreadName().startsWith("blocker-")) {
+                LockInfo lockInfo = threadInfo.getLockInfo();
+                if (lockInfo != null) {
+                    assertThat(threadInfo.getThreadName(), containsString("loading com.foo.Bar"));
+                    assertThat(threadInfo.getLockInfo().getClassName(), not(equalTo("java.util.concurrent.ConcurrentHashMap$ReservationNode")));
+                }
+            }
+        }
+        parentLoader.latch.countDown();
+    }
+
+    private static Class<?> loadClass(ClassLoader loader, String className) throws Exception {
+        return parentClassCache.get(loader).getIfPresent(className).get().get();
+    }
+
+    private static void runInNewThread(String name, ThrowingRunnable r) {
+        Thread thread = new Thread(() -> {
+            try {
+                r.run();
+            } catch (ClassNotFoundException e) {
+                // Ignore
+            } catch (Throwable e) {
+                throw new AssertionError(e);
+            }
+        }, name);
+        thread.start();
+    }
+
+    @FunctionalInterface
+    private static interface ThrowingRunnable {
+        public void run() throws Throwable;
+    }
+
+    private static class ControlledBlockingClassLoader extends ClassLoader {
+        private volatile CountDownLatch latch = new CountDownLatch(1);
+        public ControlledBlockingClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+        @Override protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            try {
+                latch.await();
+                return getParent().loadClass(name);
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
+            }
+        }
     }
 }


### PR DESCRIPTION
While working on https://github.com/jenkinsci/script-security-plugin/pull/265, I noticed that in some cases, class loading threads were blocked on internal `ConcurrentHashMap` data structures locked by other class loading threads, rather than on their parent class loader. See https://github.com/jenkinsci/script-security-plugin/pull/265#issuecomment-534251537 for details. I thought that switching to asynchronously-loaded inner caches might help this problem, and it does, but in the end, it doesn't really matter because `PluginManager.UberClassLoader` is not parallel capable ([JENKINS-23784](https://issues.jenkins-ci.org/browse/JENKINS-23784)), and as I thought, cache hits are fine either way because they do not require any locking.

I am opening this as a draft PR, and then closing it, because it adds some complexity that I'd prefer to avoid unless it actually helps us, and it needs some more testing and thought around error handling to be ready to merge.

See `SandboxResolvingClassLoaderTest.classCacheOnlyBlocksAtLoadClass` for the relevant test that fails without this change. The main benefit from this change is that the values for inner caches become `Future`s, so the insertion of the `Future` into the cache is quick, and the `ConcurrentHashMap`-internal locks are not held during the duration of calls to `parentLoader.loadClass`. The results of the `Future` are computed on a separate thread pool. If `PluginManager.UberClassLoader` was parallel capable, this change would allow multiple classes to be loaded simultaneously from the thread pool. If `PluginManager.UberClassLoader` was parallel capable but we were still using the manually-loaded cache, class loading would in practice still be serialized on internal `ConcurrentHashMap` data structures, which would be locked during the duration of calls to `parentLoader.loadClass`.

TL;DR: Without [JENKINS-23784](https://issues.jenkins-ci.org/browse/JENKINS-23784), using an async cache makes no difference to performance.