### PR TITLE
JENKINS-59952: Whitelisting all remaining java.util.regex methods

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -394,14 +394,43 @@ staticMethod java.util.UUID randomUUID
 method java.util.concurrent.Callable call
 staticField java.util.concurrent.TimeUnit HOURS
 staticField java.util.concurrent.TimeUnit MINUTES
+method java.util.regex.MatchResult end
+method java.util.regex.MatchResult end int
+method java.util.regex.MatchResult group
 method java.util.regex.MatchResult group int
-method java.util.regex.Matcher find
-method java.util.regex.Matcher group java.lang.String
+method java.util.regex.MatchResult groupCount
+method java.util.regex.MatchResult start
+method java.util.regex.MatchResult start int
+method java.util.regex.Matcher appendReplacement java.lang.StringBuffer java.lang.String
+method java.util.regex.Matcher appendTail java.lang.StringBuffer
+method java.util.regex.Matcher hasAnchoringBounds
+method java.util.regex.Matcher hasTransparentBounds
+method java.util.regex.Matcher hitEnd
+method java.util.regex.Matcher lookingAt
 method java.util.regex.Matcher matches
+method java.util.regex.Matcher pattern
+staticMethod java.util.regex.Matcher quoteReplacement java.lang.String
+method java.util.regex.Matcher region int int
+method java.util.regex.Matcher regionEnd
+method java.util.regex.Matcher regionStart
 method java.util.regex.Matcher replaceAll java.lang.String
 method java.util.regex.Matcher replaceFirst java.lang.String
+method java.util.regex.Matcher requireEnd
+method java.util.regex.Matcher reset
+method java.util.regex.Matcher reset java.lang.CharSequence
+method java.util.regex.Matcher toMatchResult
+method java.util.regex.Matcher useAnchoringBounds boolean
+method java.util.regex.Matcher usePattern java.util.regex.Pattern
+method java.util.regex.Matcher useTransparentBounds boolean
 staticMethod java.util.regex.Pattern compile java.lang.String
+staticMethod java.util.regex.Pattern compile java.lang.String int
+method java.util.regex.Pattern flags
 method java.util.regex.Pattern matcher java.lang.CharSequence
+staticMethod java.util.regex.Pattern matches java.lang.String java.lang.CharSequence
+method java.util.regex.Pattern pattern
+staticMethod java.util.regex.Pattern quote java.lang.String
+method java.util.regex.Pattern split java.lang.CharSequence
+method java.util.regex.Pattern split java.lang.CharSequence int
 method net.sf.json.JSON isArray
 method net.sf.json.JSON size
 


### PR DESCRIPTION
This change ensures that all the methods from java.util.regex package are whitelisted. There is no functionality in this package that touches external resources, so everything should be safe to be whitelisted.