### PR TITLE
Whitelist ChangeLogSet.Entry.getComment()

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/jenkins-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/jenkins-whitelist
@@ -20,6 +20,7 @@ method hudson.scm.ChangeLogSet$AffectedFile getPath
 method hudson.scm.ChangeLogSet$Entry getAffectedFiles
 method hudson.scm.ChangeLogSet$Entry getAffectedPaths
 method hudson.scm.ChangeLogSet$Entry getAuthor
+method hudson.scm.ChangeLogSet$Entry getComment
 method hudson.scm.ChangeLogSet$Entry getCommitId
 method hudson.scm.ChangeLogSet$Entry getMsg
 method hudson.scm.ChangeLogSet$Entry getMsgAnnotated


### PR DESCRIPTION
getComment() method was introduced in JENKINS-49202 but was not whitelisted at the time

This PR brings it into alignment with getMsg, getAuthor, etc