### PR TITLE
Adding support parse HEX

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -82,6 +82,7 @@ new java.lang.Exception java.lang.String
 staticField java.lang.Integer MAX_VALUE
 # could add valueOf, though currently the staticField’s need to be whitelisted, which is the more likely use case
 staticMethod java.lang.Integer parseInt java.lang.String
+staticMethod java.lang.Integer parseInt java.lang.String int
 staticMethod java.lang.Integer toString int int
 staticMethod java.lang.Integer valueOf java.lang.String
 method java.lang.Iterable iterator


### PR DESCRIPTION
Please add to whitelist static method to parse hex.
For example:
`Integer.parseInt("FF", 16)`