### PR TITLE
Add changelog for 1.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 1.70
+
+Release date: 2020-03-09
+
+* [Fix sandbox bypass vulnerability](https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1754)
+
 ## Version 1.69
 
 Release date: 2020-01-27


### PR DESCRIPTION
1.70 went out as part of [today's security advisory](https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1754).