### PR TITLE
Move 1.70 changelog entry to 1.71 and add correct entry for 1.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## Version 1.70
+## Version 1.71
 
 Release date: 2020-03-09
 
 * [Fix sandbox bypass vulnerability](https://jenkins.io/security/advisory/2020-03-09/#SECURITY-1754)
+
+## Version 1.70
+
+Release date: 2020-03-18
+
+* [Fix sandbox bypass vulnerability](https://jenkins.io/security/advisory/2020-02-12/#SECURITY-1713)
 
 ## Version 1.69
 


### PR DESCRIPTION
In #287 I only added an entry for the most recent security fix, but I used the wrong version. This PR fixes the version, and adds the real entry for 1.70, which was not documented here.