### PR TITLE
Clear static field signatures in ProxyWhitelist.reset

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/ProxyWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/ProxyWhitelist.java
@@ -90,6 +90,7 @@ public class ProxyWhitelist extends Whitelist {
             newSignatures.clear();
             staticMethodSignatures.clear();
             fieldSignatures.clear();
+            staticFieldSignatures.clear();
 
             this.delegates.add(new EnumeratingWhitelist() {
                 @Override protected List<EnumeratingWhitelist.MethodSignature> methodSignatures() {

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/ProxyWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/ProxyWhitelistTest.java
@@ -47,6 +47,14 @@ public class ProxyWhitelistTest {
         assertFalse(pw2.permitsMethod(Object.class.getMethod("hashCode"), "x", new Object[0]));
     }
 
+    @Test public void resetStaticField() throws Exception {
+        ProxyWhitelist pw1 = new ProxyWhitelist(new StaticWhitelist(new StringReader("staticField java.util.Collections EMPTY_LIST")));
+        ProxyWhitelist pw2 = new ProxyWhitelist(pw1);
+        assertTrue(pw2.permitsStaticFieldGet(Collections.class.getField("EMPTY_LIST")));
+        pw1.reset(Collections.<Whitelist>emptySet());
+        assertFalse(pw2.permitsStaticFieldGet(Collections.class.getField("EMPTY_LIST")));
+    }
+
     /** Ensures we cache at the top-level ProxyWhitelist */
     @Test
     public void caching() throws Exception {


### PR DESCRIPTION
While investigating something else, I noticed that `ProxyWhitelist.reset` didn't clear out static field  signatures when clearing out other types of signatures.