### PR TITLE
[JENKINS-61952] Add remaining methods on java.util.regex.Matcher to the whitelist

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -465,6 +465,10 @@ method java.util.regex.MatchResult start
 method java.util.regex.MatchResult start int
 method java.util.regex.Matcher appendReplacement java.lang.StringBuffer java.lang.String
 method java.util.regex.Matcher appendTail java.lang.StringBuffer
+method java.util.regex.Matcher end java.lang.String
+method java.util.regex.Matcher find
+method java.util.regex.Matcher find int
+method java.util.regex.Matcher group java.lang.String
 method java.util.regex.Matcher hasAnchoringBounds
 method java.util.regex.Matcher hasTransparentBounds
 method java.util.regex.Matcher hitEnd
@@ -480,6 +484,7 @@ method java.util.regex.Matcher replaceFirst java.lang.String
 method java.util.regex.Matcher requireEnd
 method java.util.regex.Matcher reset
 method java.util.regex.Matcher reset java.lang.CharSequence
+method java.util.regex.Matcher start java.lang.String
 method java.util.regex.Matcher toMatchResult
 method java.util.regex.Matcher useAnchoringBounds boolean
 method java.util.regex.Matcher usePattern java.util.regex.Pattern


### PR DESCRIPTION
See [JENKINS-61952](https://issues.jenkins-ci.org/browse/JENKINS-61952).

https://github.com/jenkinsci/script-security-plugin/pull/274 (CC @haridsv) accidentally removed two methods from the whitelist:

* method java.util.regex.Matcher find
* method java.util.regex.Matcher group java.lang.String

This PR adds those methods back to the whitelist. There were also three remaining `java.util.regex.Matcher` methods that were not whitelisted, so this PR also adds those methods to the whitelist:

* method java.util.regex.Matcher end java.lang.String
* method java.util.regex.Matcher find int
* method java.util.regex.Matcher start java.lang.String