### PR TITLE
implementing serializable in SecureGroovyScript & ClasspathEntry

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
@@ -37,6 +37,7 @@ import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 
 import java.beans.Introspector;
+import java.io.Serializable;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
@@ -79,8 +80,9 @@ import org.kohsuke.stapler.interceptor.RequirePOST;
  * you <strong>must</strong> call {@link #configuring} or a related method from your own constructor.
  * Use {@code <f:property field="…"/>} to configure it from Jelly.
  */
-public final class SecureGroovyScript extends AbstractDescribableImpl<SecureGroovyScript> {
+public final class SecureGroovyScript extends AbstractDescribableImpl<SecureGroovyScript> implements Serializable {
  
+    private static final long serialVersionUID = -4347442065624787928L;
     private final @Nonnull String script;
     private final boolean sandbox;
     private final @CheckForNull List<ClasspathEntry> classpath;

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntry.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.scriptsecurity.scripts;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
+import java.io.Serializable;
 
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -48,8 +49,9 @@ import javax.annotation.Nonnull;
 /**
  * A classpath entry used for a script.
  */
-public final class ClasspathEntry extends AbstractDescribableImpl<ClasspathEntry> {
+public final class ClasspathEntry extends AbstractDescribableImpl<ClasspathEntry> implements Serializable {
 
+    private static final long serialVersionUID = -2873408550951192200L;
     private final @Nonnull URL url;
     
     @DataBoundConstructor


### PR DESCRIPTION
Same as #276 . It's been 5 months since last reply. 

Only add `Serializable`. This will make plugins like active-choices-plugin compatible to pipeline script.
