### PR TITLE
Fix build errors by updating minimum core version and parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.55</version>
+    <version>4.1</version>
     <relativePath />
   </parent>
 
@@ -16,7 +16,7 @@
   <properties>
     <revision>1.72</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.176.4</jenkins.version>
     <java.level>8</java.level>
     <configuration-as-code.version>1.35</configuration-as-code.version>
   </properties>

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoader.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxResolvingClassLoader.java
@@ -75,8 +75,10 @@ class SandboxResolvingClassLoader extends ClassLoader {
 
     // We cannot have the inner cache be a LoadingCache and just use .get(name), since then the values of the outer cache would strongly refer to the keys.
     private static <T> T load(LoadingCache<ClassLoader, Cache<String, T>> cache, String name, ClassLoader parentLoader, Supplier<T> supplier) {
+        Cache<String, T> classCache = cache.get(parentLoader);
+        assert classCache != null; // Never null, see makeParentCache, but we need the assertion to convince SpotBugs.
         // itemName is ignored but caffeine requires a function<String, T>
-        return cache.get(parentLoader).get(name, (String itemName) -> {
+        return classCache.get(name, (String itemName) -> {
             Thread t = Thread.currentThread();
             String origName = t.getName();
             t.setName(origName + " loading " + name);


### PR DESCRIPTION
Subsumes #257. Should fix enforcer errors seen in the CI builds when testing against 2.222.x.

2.176.x is the fourth-oldest LTS line at this point, so it seems like a conservative enough upgrade. The core BOM used by version 4.x of the parent POM also supports 2.164.3 if we want to be even more conservative.