### PR TITLE
Update caffeine to 2.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>2.7.0</version>
+      <version>2.8.2</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>


### PR DESCRIPTION
The reason for the update is just that security scanners are complaining about https://github.com/ben-manes/caffeine/issues/301. As far as I can tell there is no actual issue because the library author verified that the build was reproducible.

Release notes for the library can be found [here](https://github.com/ben-manes/caffeine/releases).