### PR TITLE
Add result color related methods to Jenkins whitelist

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/jenkins-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/jenkins-whitelist
@@ -1,6 +1,7 @@
 # Useful Jenkins API methods:
 new hudson.EnvVars
 method hudson.model.AbstractBuild getEnvironments
+method hudson.model.BallColor getHtmlBaseColor
 staticMethod hudson.model.Environment create hudson.EnvVars
 method hudson.model.Item getParent
 method hudson.model.ModelObject getDisplayName
@@ -9,6 +10,8 @@ staticField hudson.model.Result FAILURE
 staticField hudson.model.Result NOT_BUILT
 staticField hudson.model.Result SUCCESS
 staticField hudson.model.Result UNSTABLE
+field hudson.model.Result color
+staticMethod hudson.model.Result fromString java.lang.String
 method hudson.model.Run getFullDisplayName
 method hudson.model.User getFullName
 method hudson.model.User getId


### PR DESCRIPTION
Adds three result color related methods to the Jenkins whitelist. I took a quick look at these methods and they seemed safe to me; however, I do not have a full understanding of how to evaluate safety, so if these methods are unsafe I would appreciate an explanation as to why.

For background, I use these methods in my pipelines as follows:

```groovy
/**
 * Return a Slack color from a given Jenkins result.
 *
 * @param resultStr The Jenkins job result, as returned by {@link RunWrapper#getResult()}. Typically
 * this is the value of {@code currentBuild.result}.
 * @return A valid Slack color. This is typically one of the predefined Slack colors or otherwise
 * the value of {@link BallColor#getHtmlBaseColor()}.
 */
def getSlackColor(String resultStr) {
  Result result = Result.fromString(resultStr)
  if (result == Result.SUCCESS) {
    return 'good'
  } else if (result == Result.UNSTABLE) {
    return 'warning'
  } else if (result == Result.FAILURE) {
    return 'danger'
  } else {
    return result.color.htmlBaseColor
  }
}
```

And I call the `getSlackColor` method as follows:

```
slackSend(channel: '#foo', color: getSlackColor(currentBuild.result), message: '[…]')
```