### PR TITLE
Replace use of recommendedPlugins with explicit configurations in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "11", jenkins: "2.222.3", javaLevel: 8 ]
+])


### PR DESCRIPTION
#293 fixed the build after it was broken by jenkins-infra/pipeline-library#92, but then jenkins-infra/pipeline-library#146 broke it again.

This PR stops using `buildPlugin.recommendedConfigurations` to avoid these kinds of issues in the first place.