### PR TITLE
Add category to In-process Script Approval management link

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalLink.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalLink.java
@@ -75,4 +75,9 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
         return Jenkins.RUN_SCRIPTS;
     }
 
+    // TODO: Override `getCategory` instead using `Category.SECURITY` when minimum core version is 2.226+, see https://github.com/jenkinsci/jenkins/commit/6de7e5fc7f6fb2e2e4cb342461788f97e3dfd8f6.
+    protected String getCategoryName() {
+        return "SECURITY";
+    }
+
 }


### PR DESCRIPTION
https://github.com/jenkinsci/jenkins/pull/4546 in Jenkins 2.226+ improves the layout of the "Manage Jenkins" page by categorizing the links. We should go ahead and implement `getCategoryName` even without updating the minimum core version here so that the "In-process Script Approval" link shows up in the security category in newer versions of Jenkins instead of being uncategorized.