### PR TITLE
[JENKINS-63218] Add a script approval endpoint for Groovy Scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,16 +92,37 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
+      <!--      TODO: review once the plugin is migrated to the BOM-->
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
       <scope>test</scope>
+      <!--      TODO: review once the plugin is migrated to the BOM-->
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito2</artifactId>
       <scope>test</scope>
+      <!--      TODO: review once the plugin is migrated to the BOM-->
+      <exclusions>
+        <exclusion>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+      </exclusion>
+    </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -88,5 +88,20 @@
       <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.scriptsecurity.scripts;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import groovy.lang.GroovyClassLoader;
 import hudson.model.Api;
 import jenkins.model.GlobalConfiguration;
@@ -967,6 +968,7 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
     @Exported
     @RequirePOST
     @Restricted(NoExternalUse.class)
+    @SuppressFBWarnings(value = "DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED", justification = "Irrelevant without SecurityManager.")
     public HttpResponse doApproveGroovy(StaplerRequest request) throws IOException {
         if(!Jenkins.get().hasPermission(Jenkins.RUN_SCRIPTS)) {
             return HttpResponses.forbidden();

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/_api.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/_api.jelly
@@ -1,0 +1,21 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+
+  <h2>Approving a new Groovy script for usage</h2>
+  <p>
+    To programmatically approve a script, post to <a href="../approveGroovy">this URL</a>.
+    The Groovy script you want to approve is expected as a query parameter named script.
+    This parameter is mandatory.
+
+    Note: if the script was already approved, this is a NOOP and the caller will receive a 200 http response nonetheless.
+
+    Response will be:
+    <ul>
+      <li> 200 if the script was successfully added to the approved scripts</li>
+      <li> 403 if the user does not have the RUN_SCRIPT permission</li>
+    </ul>
+
+    Usage example: curl -LX POST -u $USERNAME:$TOKEN $JENKINS_URL/scriptApproval/approveGroovy --data-binary  @script.groovy
+  </p>
+
+</j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalRestEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalRestEndpointTest.java
@@ -1,0 +1,118 @@
+package org.jenkinsci.plugins.scriptsecurity.scripts;
+
+import hudson.PluginManager;
+import hudson.security.Permission;
+import jenkins.model.Jenkins;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.scriptsecurity.scripts.languages.GroovyLanguage;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Jenkins.class, GroovyLanguage.class})
+public class ScriptApprovalRestEndpointTest {
+    @Mock
+    private Jenkins jenkins;
+    @Mock
+    private PluginManager pluginManager;
+
+    @Mock
+    StaplerResponse resp;
+    @Mock
+    StaplerRequest request;
+
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+        mockStatic(Jenkins.class);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.get()).thenReturn(jenkins);
+        when(jenkins.getRootDir()).thenReturn(folder.getRoot());
+        when(jenkins.getPluginManager()).thenReturn(pluginManager);
+        mockStatic(GroovyLanguage.class);
+        when(GroovyLanguage.get()).thenReturn(new GroovyLanguage());
+    }
+
+    @Test
+    public void approvingScriptWithoutScriptPermissionFails() throws IOException, ServletException {
+        when(jenkins.hasPermission(Mockito.any(Permission.class))).thenReturn(false);
+
+        ScriptApproval scriptApproval = new ScriptApproval();
+        HttpResponse httpResponse = scriptApproval.doApproveGroovy(request);
+
+        httpResponse.generateResponse(null, resp, null);
+        verify(resp).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    }
+
+    @Test
+    public void approvingScriptPersistsTheProvidedScript() throws IOException, ServletException {
+        when(jenkins.hasPermission(Mockito.any(Permission.class))).thenReturn(true);
+        when(request.getInputStream()).thenReturn(new Stream("println 'hello'"));
+        String scriptHash = "20c13e13468ed85bc683546136489d8f75b87148"; // maybe we could make hash package protected for tests?
+
+        ScriptApproval scriptApproval = new ScriptApproval();
+        HttpResponse httpResponse = scriptApproval.doApproveGroovy(request);
+
+        httpResponse.generateResponse(null, resp, null);
+        verify(resp).setStatus(HttpServletResponse.SC_OK);
+        assertThat(scriptApproval.isScriptHashApproved(scriptHash), is(true));
+
+        // validate persistence
+        assertThat(new ScriptApproval().isScriptHashApproved(scriptHash), is(true));
+    }
+
+    private static class Stream extends ServletInputStream {
+        private final InputStream inputStream;
+
+        Stream(String script) throws IOException {
+            inputStream = IOUtils.toInputStream(script, "UTF-8");
+        }
+
+        @Override
+        public int read() throws IOException {
+            return inputStream.read();
+        }
+
+        @Override
+        public boolean isFinished() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isReady() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalRestEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalRestEndpointTest.java
@@ -15,6 +15,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -31,6 +32,8 @@ import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
+// workaround for PowerMock with java 11, see https://github.com/powermock/powermock/issues/864
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*"})
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Jenkins.class, GroovyLanguage.class})
 public class ScriptApprovalRestEndpointTest {
@@ -43,7 +46,6 @@ public class ScriptApprovalRestEndpointTest {
     StaplerResponse resp;
     @Mock
     StaplerRequest request;
-
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();


### PR DESCRIPTION
Some details I'm not sure about:
1. Regarding the return code, as I'm technically creating a resource I should probably return an http created code, but it would also mean providing a location, I'm not 100% clear what that should be. Therefore I chose to return an http ok for now.
2. I'm not 100% sure about what the checkScriptForCompilationErrors is exactly catching, I made some obviously compilation error and it wasn't caught, therefore I couldn't manually test this use case.