### PR TITLE
Use ACI agents to run CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(configurations: [
+buildPlugin(useAci: true, configurations: [
   [ platform: "linux", jdk: "8", jenkins: null ],
   [ platform: "windows", jdk: "8", jenkins: null ],
   [ platform: "linux", jdk: "11", jenkins: "2.222.3", javaLevel: 8 ]


### PR DESCRIPTION
#306 (which is just changelog updates) was failing in the Java 11 branch, and I noticed it was using one of the "High Memory" EC2 instances, which is a waste of resources. We should use ACI agents instead as long as there are no issues.