### PR TITLE
Bump caffeine version - required for bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>2.8.2</version>
+      <version>2.8.5</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>


### PR DESCRIPTION
This increases the pulled in version of error_prone_annotations

It is required for solving upper bounds issues:
https://github.com/jenkinsci/bom/pull/322

https://github.com/ben-manes/caffeine/blob/fe0131bb4d6dbfca5db4bbb7a06f5b14b92b4ca2/gradle/dependencies.gradle#L39
https://github.com/ben-manes/caffeine/blob/fe0131bb4d6dbfca5db4bbb7a06f5b14b92b4ca2/gradle/dependencies.gradle#L114

Maybe it should be a library plugin, but this should solve it for now,

@dwnusbaum @jglick 