### PR TITLE
JENKINS-64057: Whitelist XmlUtil and a few java.util scripts

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -12,6 +12,7 @@ staticMethod groovy.json.JsonOutput toJson java.util.Calendar
 staticMethod groovy.json.JsonOutput toJson java.util.Date
 staticMethod groovy.json.JsonOutput toJson java.util.Map
 staticMethod groovy.json.JsonOutput toJson java.util.UUID
+staticMethod groovy.xml.XmlUtil escapeXml java.lang.String
 new groovy.json.JsonSlurper
 method groovy.json.JsonSlurper parseText java.lang.String
 
@@ -478,6 +479,7 @@ staticField java.time.format.DateTimeFormatter ISO_ZONED_DATE_TIME
 staticField java.time.format.DateTimeFormatter RFC_1123_DATE_TIME
 staticMethod java.time.format.DateTimeFormatter ofPattern java.lang.String
 new java.util.ArrayList java.util.Collection
+new java.util.concurrent.LinkedBlockingQueue
 staticMethod java.util.Arrays asList java.lang.Object[]
 staticMethod java.util.Arrays toString java.lang.Object[]
 staticMethod java.util.Base64 getDecoder
@@ -739,10 +741,14 @@ method java.util.Random nextInt int
 method java.util.Random nextLong
 staticMethod java.util.TimeZone getTimeZone java.lang.String
 new java.util.TreeSet
+new java.util.TreeMap
 staticMethod java.util.UUID randomUUID
 method java.util.concurrent.Callable call
+method java.util.concurrent.BlockingQueue poll long java.util.concurrent.TimeUnit
 staticField java.util.concurrent.TimeUnit HOURS
 staticField java.util.concurrent.TimeUnit MINUTES
+staticField java.util.concurrent.TimeUnit SECONDS
+staticField java.util.concurrent.TimeUnit MILLISECONDS
 method java.util.regex.MatchResult end
 method java.util.regex.MatchResult end int
 method java.util.regex.MatchResult group

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -742,9 +742,7 @@ staticMethod java.util.TimeZone getTimeZone java.lang.String
 new java.util.TreeMap
 new java.util.TreeSet
 staticMethod java.util.UUID randomUUID
-method java.util.concurrent.BlockingQueue poll long java.util.concurrent.TimeUnit
 method java.util.concurrent.Callable call
-new java.util.concurrent.LinkedBlockingQueue
 staticField java.util.concurrent.TimeUnit HOURS
 staticField java.util.concurrent.TimeUnit MILLISECONDS
 staticField java.util.concurrent.TimeUnit MINUTES

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -739,15 +739,15 @@ method java.util.Random nextInt
 method java.util.Random nextInt int
 method java.util.Random nextLong
 staticMethod java.util.TimeZone getTimeZone java.lang.String
-new java.util.TreeSet
 new java.util.TreeMap
+new java.util.TreeSet
 staticMethod java.util.UUID randomUUID
 method java.util.concurrent.BlockingQueue poll long java.util.concurrent.TimeUnit
 method java.util.concurrent.Callable call
 new java.util.concurrent.LinkedBlockingQueue
 staticField java.util.concurrent.TimeUnit HOURS
-staticField java.util.concurrent.TimeUnit MINUTES
 staticField java.util.concurrent.TimeUnit MILLISECONDS
+staticField java.util.concurrent.TimeUnit MINUTES
 staticField java.util.concurrent.TimeUnit SECONDS
 method java.util.regex.MatchResult end
 method java.util.regex.MatchResult end int

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -12,7 +12,6 @@ staticMethod groovy.json.JsonOutput toJson java.util.Calendar
 staticMethod groovy.json.JsonOutput toJson java.util.Date
 staticMethod groovy.json.JsonOutput toJson java.util.Map
 staticMethod groovy.json.JsonOutput toJson java.util.UUID
-staticMethod groovy.xml.XmlUtil escapeXml java.lang.String
 new groovy.json.JsonSlurper
 method groovy.json.JsonSlurper parseText java.lang.String
 
@@ -38,6 +37,7 @@ method groovy.lang.Range getTo
 method groovy.lang.Range step int
 method groovy.lang.Range step int groovy.lang.Closure
 method groovy.lang.Script getBinding
+staticMethod groovy.xml.XmlUtil escapeXml java.lang.String
 
 method java.io.Flushable flush
 # Useful to show stacktrace to the user.
@@ -479,7 +479,6 @@ staticField java.time.format.DateTimeFormatter ISO_ZONED_DATE_TIME
 staticField java.time.format.DateTimeFormatter RFC_1123_DATE_TIME
 staticMethod java.time.format.DateTimeFormatter ofPattern java.lang.String
 new java.util.ArrayList java.util.Collection
-new java.util.concurrent.LinkedBlockingQueue
 staticMethod java.util.Arrays asList java.lang.Object[]
 staticMethod java.util.Arrays toString java.lang.Object[]
 staticMethod java.util.Base64 getDecoder
@@ -743,12 +742,13 @@ staticMethod java.util.TimeZone getTimeZone java.lang.String
 new java.util.TreeSet
 new java.util.TreeMap
 staticMethod java.util.UUID randomUUID
-method java.util.concurrent.Callable call
 method java.util.concurrent.BlockingQueue poll long java.util.concurrent.TimeUnit
+method java.util.concurrent.Callable call
+new java.util.concurrent.LinkedBlockingQueue
 staticField java.util.concurrent.TimeUnit HOURS
 staticField java.util.concurrent.TimeUnit MINUTES
-staticField java.util.concurrent.TimeUnit SECONDS
 staticField java.util.concurrent.TimeUnit MILLISECONDS
+staticField java.util.concurrent.TimeUnit SECONDS
 method java.util.regex.MatchResult end
 method java.util.regex.MatchResult end int
 method java.util.regex.MatchResult group


### PR DESCRIPTION
This would whitelist the following signatures:

- staticMethod groovy.xml.XmlUtil escapeXml java.lang.String
- staticField java.util.concurrent.TimeUnit MILLISECONDS
- staticField java.util.concurrent.TimeUnit SECONDS
- new java.util.TreeMap

All of these signatures are utility classes and hence, it should be safe to whitelist them. 