### PR TITLE
Malformed signatures will no longer be added to approved signatures

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
@@ -187,7 +187,7 @@ public final class StaticWhitelist extends EnumeratingWhitelist {
             }
             return new StaticFieldSignature(toks[1], toks[2]);
         } else {
-            throw new IOException(line);
+            throw new IOException("Malformed signature entry: '" + line + "'");
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -707,7 +707,7 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
             try {
                 reconfigure();
             } catch (IOException e) {
-                LOG.log(Level.SEVERE, "Malformed signature entry in scriptApproval.xml: '" + e.getMessage() + "'");
+                LOG.log(Level.SEVERE, e.getMessage() + " in scriptApproval.xml");
             }
         }
 
@@ -796,8 +796,15 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
         Jenkins.getInstance().checkPermission(Jenkins.RUN_SCRIPTS);
         pendingSignatures.remove(new PendingSignature(signature, false, ApprovalContext.create()));
         approvedSignatures.add(signature);
-        save();
-        return reconfigure();
+        try {
+            return reconfigure();
+        } catch (IOException e) {
+            approvedSignatures.remove(signature);
+            LOG.log(Level.SEVERE, e.getMessage());
+            throw e;
+        } finally {
+            save();
+        }
     }
 
     @Restricted(NoExternalUse.class) // for use from AJAX
@@ -805,8 +812,15 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
         Jenkins.getInstance().checkPermission(Jenkins.RUN_SCRIPTS);
         pendingSignatures.remove(new PendingSignature(signature, false, ApprovalContext.create()));
         aclApprovedSignatures.add(signature);
-        save();
-        return reconfigure();
+        try {
+            return reconfigure();
+        } catch (IOException e) {
+            aclApprovedSignatures.remove(signature);
+            LOG.log(Level.SEVERE, e.getMessage());
+            throw e;
+        } finally {
+            save();
+        }
     }
 
     @Restricted(NoExternalUse.class) // for use from AJAX


### PR DESCRIPTION
Adding a malformed signature causes hanging of "In-process Script Approval " like https://issues.jenkins.io/browse/JENKINS-46764.
To avoid this, malformed signatures will no longer be added to the approved list.