### PR TITLE
[JENKINS-62708] Add JCasC support for approved script hashes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -66,6 +66,7 @@ import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.model.Jenkins;
@@ -699,6 +700,27 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
     @Restricted(NoExternalUse.class) // Jelly, implementation
     public synchronized String[] getAclApprovedSignatures() {
         return aclApprovedSignatures.toArray(new String[aclApprovedSignatures.size()]);
+    }
+
+    @DataBoundSetter
+    public synchronized void setApprovedScriptHashes(String[] scriptHashes) throws IOException {
+        Jenkins.getInstance().checkPermission(Jenkins.RUN_SCRIPTS);
+        approvedScriptHashes.clear();
+        Pattern sha1Pattern = Pattern.compile("[a-fA-F0-9]{40}");
+        for (String scriptHash : scriptHashes) {
+            if (scriptHash != null && sha1Pattern.matcher(scriptHash).matches()) {
+                approvedScriptHashes.add(scriptHash);
+            } else {
+                LOG.warning(() -> "Ignoring malformed script hash: " + scriptHash);
+            }
+        }
+        save();
+        reconfigure();
+    }
+
+    @Restricted(NoExternalUse.class) // Jelly, implementation
+    public synchronized String[] getApprovedScriptHashes() {
+        return approvedScriptHashes.toArray(new String[approvedScriptHashes.size()]);
     }
 
     @Restricted(NoExternalUse.class) // implementation

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/JcascTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/JcascTest.java
@@ -26,6 +26,9 @@ public class JcascTest {
         String[] approved = ScriptApproval.get().getApprovedSignatures();
         assertTrue(approved.length == 1);
         assertEquals(approved[0], "method java.net.URI getHost");
+        String[] approvedScriptHashes = ScriptApproval.get().getApprovedScriptHashes();
+        assertTrue(approvedScriptHashes.length == 1);
+        assertEquals(approvedScriptHashes[0], "fccae58c5762bdd15daca97318e9d74333203106");
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
@@ -162,15 +162,20 @@ public class ScriptApprovalTest extends AbstractApprovalTest<ScriptApprovalTest.
         assertEquals(0, sa.getDangerousApprovedSignatures().length);
     }
 
-    @Issue("JENKINS-57563")
-    @LocalData // Just a scriptApproval.xml that whitelists 'staticMethod jenkins.model.Jenkins getInstance'
+    @Issue({"JENKINS-57563", "JENKINS-62708"})
+    @LocalData // Just a scriptApproval.xml that whitelists 'staticMethod jenkins.model.Jenkins getInstance' and a script printing all labels
     @Test
     public void upgradeSmokes() throws Exception {
+        configureSecurity();
         FreeStyleProject p = r.createFreeStyleProject();
         p.getPublishersList().add(new TestGroovyRecorder(
                 new SecureGroovyScript("jenkins.model.Jenkins.instance", true, null)));
+        p.getPublishersList().add(new TestGroovyRecorder(
+                new SecureGroovyScript("println(jenkins.model.Jenkins.instance.getLabels())", false, null)));
         r.assertLogNotContains("org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: "
                         + "Scripts not permitted to use staticMethod jenkins.model.Jenkins getInstance",
+                r.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get()));
+        r.assertLogNotContains("org.jenkinsci.plugins.scriptsecurity.scripts.UnapprovedUsageException: script not yet approved for use",
                 r.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get()));
     }
 

--- a/src/test/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest/upgradeSmokes/scriptApproval.xml
+++ b/src/test/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest/upgradeSmokes/scriptApproval.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <scriptApproval plugin="script-security@1.24">
-  <approvedScriptHashes/>
+  <approvedScriptHashes>
+    <string>fccae58c5762bdd15daca97318e9d74333203106</string>
+  </approvedScriptHashes>
   <approvedSignatures>
     <string>staticMethod jenkins.model.Jenkins getInstance</string>
   </approvedSignatures>

--- a/src/test/resources/org/jenkinsci/plugins/scriptsecurity/scripts/smoke_test.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/scriptsecurity/scripts/smoke_test.yaml
@@ -2,3 +2,5 @@ security:
   scriptApproval:
     approvedSignatures:
     - method java.net.URI getHost
+    approvedScriptHashes:
+    - fccae58c5762bdd15daca97318e9d74333203106

--- a/src/test/resources/org/jenkinsci/plugins/scriptsecurity/scripts/smoke_test_expected.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/scriptsecurity/scripts/smoke_test_expected.yaml
@@ -1,2 +1,4 @@
+approvedScriptHashes:
+- "fccae58c5762bdd15daca97318e9d74333203106"
 approvedSignatures:
 - "method java.net.URI getHost"


### PR DESCRIPTION
Adds the ability to manage approved script hashes with JCasC. With the current UX to determine the hash you can either approve it and see what was added to the scriptApproval.xml file on disk or compute the SHA-1 of the script. There is an open effort to approve the UX with [JENKINS-62448](https://issues.jenkins.io/browse/JENKINS-62448) https://github.com/jenkinsci/script-security-plugin/pull/300.

Example:
Script:
`println(jenkins.model.Jenkins.instance.getLabels())`

```
security:
  scriptApproval:
    approvedScriptHashes:
      - fccae58c5762bdd15daca97318e9d74333203106 -- print all labels
```

See [JENKINS-62708](https://issues.jenkins.io/browse/JENKINS-62708)