### PR TITLE
Configure Dependabot to ignore Caffeine 3.x due to Java 11 requirement

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       - "dwnusbaum"
     schedule:
       interval: "daily"
+    ignore:
+      # Caffeine 3.x requires Java 11, so we cannot update until Jenkins requires Java 11
+      - dependency-name: "com.github.ben-manes.caffeine:caffeine"
+        versions: ["3.x"]

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>2.9.0</version>
+      <version>2.9.0</version> <!-- 3.0.0 requires Java 11. -->
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>


### PR DESCRIPTION
See #331 and https://github.com/ben-manes/caffeine/releases/tag/v3.0.0.

We cannot update `caffeine` to 3.0.0 until a version of Jenkins that requires Java 11 is released and we are ready to update the minimum supported Jenkins version here in `script-security` to that version.

Maybe it would be make sense to try to replace the `caffeine` dependency with a small API on top of `ConcurrentHashMap` or similar if we are not going to be able to update the dependency for a long time. Personally, I am not as concerned about the performance of the caching layer (at least as long as the performance is not terrible) as I am about its correctness, so from my PoV the main benefit of switching to `caffeine` in #160 was that we could avoid the concurrency-related issues we were occasionally seeing with the Guava cache (admittedly, Jenkins is using a very old version of Guava).

Closes #331.