### PR TITLE
Update minimum required core version to 2.222.4 and update JCasC dependency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(useAci: true, configurations: [
-  [ platform: "linux", jdk: "8", jenkins: null ],
-  [ platform: "windows", jdk: "8", jenkins: null ],
-  [ platform: "linux", jdk: "11", jenkins: "2.222.3", javaLevel: 8 ]
+  [ platform: "linux", jdk: "8" ],
+  [ platform: "windows", jdk: "8" ],
+  [ platform: "linux", jdk: "11", javaLevel: 8 ]
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
   <properties>
     <revision>1.77</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.176.4</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
-    <configuration-as-code.version>1.35</configuration-as-code.version>
+    <configuration-as-code.version>1.47</configuration-as-code.version>
   </properties>
   <licenses>
     <license>


### PR DESCRIPTION
Updating the minimum core version of this plugin to 2.222.4 allows us to test against the current version of JCasC. 2.222.4 is a fairly conservative choice: http://stats.jenkins.io/pluginversions/script-security.html indicates that 95% of users who are running `script-security` 1.75 (there are no stats yet for 1.76) are already running Jenkins 2.222.4 or newer.

Closes #333.