### PR TITLE
`Base64` whitelists did not work due to use of canonical rather than binary name

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/EnumeratingWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/EnumeratingWhitelist.java
@@ -218,6 +218,7 @@ public abstract class EnumeratingWhitelist extends Whitelist {
         }
         abstract boolean exists() throws Exception;
         final Class<?> type(String name) throws Exception {
+            // TODO this should be more strict: binary name is required for nested classes
             return ClassUtils.getClass(name);
         }
         final Class<?>[] types(String[] names) throws Exception {

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -487,13 +487,13 @@ staticMethod java.util.Base64 getMimeEncoder
 staticMethod java.util.Base64 getMimeEncoder int byte[]
 staticMethod java.util.Base64 getUrlDecoder
 staticMethod java.util.Base64 getUrlEncoder
-method java.util.Base64.Decoder decode byte[]
-method java.util.Base64.Decoder decode byte[] byte[]
-method java.util.Base64.Decoder decode java.lang.String
-method java.util.Base64.Encoder encode byte[]
-method java.util.Base64.Encoder encode byte[] byte[]
-method java.util.Base64.Encoder encodeToString byte[]
-method java.util.Base64.Encoder withoutPadding
+method java.util.Base64$Decoder decode byte[]
+method java.util.Base64$Decoder decode byte[] byte[]
+method java.util.Base64$Decoder decode java.lang.String
+method java.util.Base64$Encoder encode byte[]
+method java.util.Base64$Encoder encode byte[] byte[]
+method java.util.Base64$Encoder encodeToString byte[]
+method java.util.Base64$Encoder withoutPadding
 staticField java.util.Calendar ALL_STYLES
 staticField java.util.Calendar AM
 staticField java.util.Calendar AM_PM


### PR DESCRIPTION
Mistake in #309/#310.
