### PR TITLE
JENKINS-65563: Whitelist signatures to allow some dynamism

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -15,7 +15,14 @@ staticMethod groovy.json.JsonOutput toJson java.util.UUID
 new groovy.json.JsonSlurper
 method groovy.json.JsonSlurper parseText java.lang.String
 
+new groovy.lang.Binding
+method groovy.lang.Binding getVariable java.lang.String
+method groovy.lang.Binding getVariables
 method groovy.lang.Binding hasVariable java.lang.String
+# FIXME: This fails test as non-existent method. Jenkins sandbox error for accessing this method is also strange looking, it says:
+#  Scripts not permitted to use method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object (groovy.lang.Binding removeVariable java.lang.String).
+#method groovy.lang.Binding removeVariable java.lang.String
+method groovy.lang.Binding setVariable java.lang.String java.lang.Object
 staticField groovy.lang.Closure DELEGATE_FIRST
 staticField groovy.lang.Closure DELEGATE_ONLY
 staticField groovy.lang.Closure OWNER_FIRST
@@ -32,11 +39,14 @@ method groovy.lang.Closure ncurry int java.lang.Object[]
 method groovy.lang.Closure setDelegate java.lang.Object
 method groovy.lang.Closure setResolveStrategy int
 method groovy.lang.GString plus java.lang.String
+method groovy.lang.GroovyObject getProperty java.lang.String
+method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object
 method groovy.lang.Range getFrom
 method groovy.lang.Range getTo
 method groovy.lang.Range step int
 method groovy.lang.Range step int groovy.lang.Closure
 method groovy.lang.Script getBinding
+method groovy.lang.Script setBinding groovy.lang.Binding
 
 method java.io.Flushable flush
 # Useful to show stacktrace to the user.
@@ -677,6 +687,7 @@ method java.util.Date setTime long
 method java.util.Date setYear int
 method java.util.Date toGMTString
 method java.util.Date toLocaleString
+new java.util.HashMap
 new java.util.HashSet
 new java.util.HashSet java.util.Collection
 method java.util.Iterator hasNext
@@ -1117,6 +1128,7 @@ staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sort java.util.Ite
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sort java.util.Iterator java.util.Comparator
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sort java.util.Map
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sort java.util.Map groovy.lang.Closure
+staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods sort java.util.Map java.util.Comparator
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.lang.String
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.util.Collection groovy.lang.Closure
 staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.util.List groovy.lang.Closure

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -39,8 +39,6 @@ method groovy.lang.Closure ncurry int java.lang.Object[]
 method groovy.lang.Closure setDelegate java.lang.Object
 method groovy.lang.Closure setResolveStrategy int
 method groovy.lang.GString plus java.lang.String
-method groovy.lang.GroovyObject getProperty java.lang.String
-method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object
 method groovy.lang.Range getFrom
 method groovy.lang.Range getTo
 method groovy.lang.Range step int


### PR DESCRIPTION
This change whitelists the following to address [JENKINS-65563](https://issues.jenkins.io/browse/JENKINS-65563):
- Most of `Binding` signatures (except `removeVariable` which I couldn't figure out how to, see code comment) to allow a script to dynamically update its namespace.
- `getProperty` and `invokeMethod` to allow handling properties and method calls dynamically.
- Also includes a couple of missing `HashMap` APIs.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
