### PR TITLE
Allow `FlowInterruptedException#getResult`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>caffeine-api</artifactId>
     </dependency>

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/jenkins-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/jenkins-whitelist
@@ -34,3 +34,4 @@ field hudson.scm.EditType EDIT
 method hudson.scm.EditType getName
 method hudson.tools.ToolInstallation getHome
 method hudson.tools.ToolInstallation getName
+method org.jenkinsci.plugins.workflow.steps.FlowInterruptedException getResult


### PR DESCRIPTION
Useful for implementing the following pattern in Pipeline jobs:

```groovy
import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException

currentBuild.result = 'SUCCESS'

try {
  […] // Main
} catch (FlowInterruptedException fie) {
  currentBuild.result = fie.result.toString()
  throw fie
} catch (err) {
  currentBuild.result = 'FAILURE'
  throw err
} finally {
  […] // Something that needs access to the result, like sending a Slack message
}
```

I suggest that the example on the [the CloudBees support site](https://support.cloudbees.com/hc/en-us/articles/218554077-how-to-set-current-build-result-in-pipeline) be updated as described above. This version is better because it allows aborted builds to propagate their `ABORTED` status to the notification.