### PR TITLE
Do not request review from @dwnusbaum on Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
-    reviewers:
-      - "dwnusbaum"
     schedule:
       interval: "daily"
     ignore:


### PR DESCRIPTION
I am not actively maintaining this plugin, so it doesn't make sense to have Dependabot request my review directly.