### PR TITLE
Bump `groovy-sandbox` from 1.27 to 1.28-20211120.231623-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <jenkins.version>2.222.4</jenkins.version>
     <java.level>8</java.level>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <enforcer.skip>true</enforcer.skip>
   </properties>
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>groovy-sandbox</artifactId>
-      <version>1.27</version>
+      <version>1.28-20211120.231623-1</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
Not for review. Filing for testing purposes. The timestamped snapshot comes from [jenkinsci/groovy-sandbox#73](https://github.com/jenkinsci/groovy-sandbox/pull/73).