### PR TITLE
Simplify CI matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(useAci: true, configurations: [
-  [ platform: "linux", jdk: "8" ],
   [ platform: "windows", jdk: "8" ],
-  [ platform: "linux", jdk: "11", javaLevel: 8 ]
+  [ platform: "linux", jdk: "11" ]
 ])


### PR DESCRIPTION
So long as we test on Linux & Windows, and 8 & 11, I think we are OK. Also `javaLevel` is deprecated.