### PR TITLE
Do not use Guava's `NullOutputStream`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelectorTest.java
@@ -24,13 +24,14 @@
 
 package org.jenkinsci.plugins.scriptsecurity.sandbox.groovy;
 
-import com.google.common.io.NullOutputStream;
 import groovy.lang.Binding;
 import groovy.lang.GString;
 import groovy.lang.Script;
 import hudson.EnvVars;
 import hudson.model.BooleanParameterValue;
 import hudson.model.Hudson;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -59,7 +60,12 @@ public class GroovyCallSiteSelectorTest {
     }
 
     @Test public void overloads() throws Exception {
-        PrintWriter receiver = new PrintWriter(new NullOutputStream());
+        PrintWriter receiver = new PrintWriter(new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                // Do nothing, we do not care
+            }
+        });
         assertEquals(PrintWriter.class.getMethod("print", Object.class), GroovyCallSiteSelector.method(receiver, "print", new Object[] {new Object()}));
         assertEquals(PrintWriter.class.getMethod("print", String.class), GroovyCallSiteSelector.method(receiver, "print", new Object[] {"message"}));
         assertEquals(PrintWriter.class.getMethod("print", int.class), GroovyCallSiteSelector.method(receiver, "print", new Object[] {42}));


### PR DESCRIPTION
Its location has been changed in Guava 14 meaning the tests of this plugin work fine with current baseline but fail with the PCT on the upcoming lts or when baseline is updated.

I could also wait for `2.332.1` to be released and then change the baseline and update the related Guava code, but I believe is simpler to just get rid of the related Guava usage in the test given how simple it is.

*This does not affect production code* but breaks any pipeline trying to run the PCT or the tests of this plugin with newer core versions

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
