### PR TITLE
[JENKINS-68070] Adapt generic-whitelist to Java standard library changes in Java 15+

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/EnumeratingWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/EnumeratingWhitelist.java
@@ -314,7 +314,7 @@ public abstract class EnumeratingWhitelist extends Whitelist {
     public static class MethodSignature extends Signature {
         final String receiverType, method;
         final String[] argumentTypes;
-        public MethodSignature(String receiverType, String method, String[] argumentTypes) {
+        public MethodSignature(String receiverType, String method, String... argumentTypes) {
             this.receiverType = receiverType;
             this.method = method;
             this.argumentTypes = argumentTypes.clone();
@@ -360,7 +360,7 @@ public abstract class EnumeratingWhitelist extends Whitelist {
     }
 
     static class StaticMethodSignature extends MethodSignature {
-        StaticMethodSignature(String receiverType, String method, String[] argumentTypes) {
+        StaticMethodSignature(String receiverType, String method, String... argumentTypes) {
             super(receiverType, method, argumentTypes);
         }
         @Override public String toString() {

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -115,6 +115,7 @@ staticMethod java.lang.Boolean parseBoolean java.lang.String
 staticMethod java.lang.Boolean valueOf boolean
 staticMethod java.lang.Boolean valueOf java.lang.String
 method java.lang.CharSequence charAt int
+method java.lang.CharSequence isEmpty
 method java.lang.CharSequence length
 method java.lang.CharSequence subSequence int int
 method java.lang.Class getName

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -774,6 +774,14 @@ staticField java.util.concurrent.TimeUnit HOURS
 staticField java.util.concurrent.TimeUnit MILLISECONDS
 staticField java.util.concurrent.TimeUnit MINUTES
 staticField java.util.concurrent.TimeUnit SECONDS
+method java.util.random.RandomGenerator nextBoolean
+method java.util.random.RandomGenerator nextBytes byte[]
+method java.util.random.RandomGenerator nextDouble
+method java.util.random.RandomGenerator nextFloat
+method java.util.random.RandomGenerator nextGaussian
+method java.util.random.RandomGenerator nextInt
+method java.util.random.RandomGenerator nextInt int
+method java.util.random.RandomGenerator nextLong
 method java.util.regex.MatchResult end
 method java.util.regex.MatchResult end int
 method java.util.regex.MatchResult group

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/EnumeratingWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/EnumeratingWhitelistTest.java
@@ -78,8 +78,8 @@ public class EnumeratingWhitelistTest {
         assertFalse(new EnumeratingWhitelist.MethodSignature(HashMap.class, "size").exists());
         assertTrue(new EnumeratingWhitelist.MethodSignature(Map.class, "size").exists());
         assertTrue(new EnumeratingWhitelist.MethodSignature(Map.Entry.class, "getKey").exists());
-        assertTrue(new EnumeratingWhitelist.MethodSignature("java.util.Map$Entry", "getKey", new String[0]).exists());
-        assertThrows(ClassNotFoundException.class, new EnumeratingWhitelist.MethodSignature("java.util.Map.Entry", "getKey", new String[0])::exists);
+        assertTrue(new EnumeratingWhitelist.MethodSignature("java.util.Map$Entry", "getKey").exists());
+        assertThrows(ClassNotFoundException.class, new EnumeratingWhitelist.MethodSignature("java.util.Map.Entry", "getKey")::exists);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
@@ -117,32 +117,32 @@ public class StaticWhitelistTest {
      */
     private static final Set<Signature> KNOWN_GOOD_SIGNATURES = new HashSet<>(Arrays.asList(
             // From workflow-support, which is not a dependency of this plugin.
-            new MethodSignature("org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper", "getRawBuild", new String[0]),
+            new MethodSignature("org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper", "getRawBuild"),
             // From groovy-cps, which is not a dependency of this plugin.
             new StaticMethodSignature("com.cloudbees.groovy.cps.CpsDefaultGroovyMethods", "each",
-                    new String[] { "java.util.Iterator", "groovy.lang.Closure" }),
+                    "java.util.Iterator", "groovy.lang.Closure"),
             // Overrides CharSequence.isEmpty in Java 15+.
-            new MethodSignature(String.class, "isEmpty", new Class<?>[0]),
+            new MethodSignature(String.class, "isEmpty"),
             // Does not exist until Java 15.
-            new MethodSignature(CharSequence.class, "isEmpty", new Class<?>[0]),
+            new MethodSignature(CharSequence.class, "isEmpty"),
             // Override the corresponding RandomGenerator methods in Java 17+.
-            new MethodSignature(Random.class, "nextBoolean", new Class<?>[0]),
-            new MethodSignature(Random.class, "nextBytes", new Class<?>[] {byte[].class}),
-            new MethodSignature(Random.class, "nextDouble", new Class<?>[0]),
-            new MethodSignature(Random.class, "nextFloat", new Class<?>[0]),
-            new MethodSignature(Random.class, "nextGaussian", new Class<?>[0]),
-            new MethodSignature(Random.class, "nextInt", new Class<?>[0]),
-            new MethodSignature(Random.class, "nextInt", new Class<?>[] {int.class}),
-            new MethodSignature(Random.class, "nextLong", new Class<?>[0]),
+            new MethodSignature(Random.class, "nextBoolean"),
+            new MethodSignature(Random.class, "nextBytes", byte[].class),
+            new MethodSignature(Random.class, "nextDouble"),
+            new MethodSignature(Random.class, "nextFloat"),
+            new MethodSignature(Random.class, "nextGaussian"),
+            new MethodSignature(Random.class, "nextInt"),
+            new MethodSignature(Random.class, "nextInt", int.class),
+            new MethodSignature(Random.class, "nextLong"),
             // Do not exist until Java 17.
-            new MethodSignature("java.util.random.RandomGenerator", "nextBoolean", new String[0]),
-            new MethodSignature("java.util.random.RandomGenerator", "nextBytes", new String[] {"byte[]"}),
-            new MethodSignature("java.util.random.RandomGenerator", "nextDouble", new String[0]),
-            new MethodSignature("java.util.random.RandomGenerator", "nextFloat", new String[0]),
-            new MethodSignature("java.util.random.RandomGenerator", "nextGaussian", new String[0]),
-            new MethodSignature("java.util.random.RandomGenerator", "nextInt", new String[0]),
-            new MethodSignature("java.util.random.RandomGenerator", "nextInt", new String[] {"int"}),
-            new MethodSignature("java.util.random.RandomGenerator", "nextLong", new String[0])
+            new MethodSignature("java.util.random.RandomGenerator", "nextBoolean"),
+            new MethodSignature("java.util.random.RandomGenerator", "nextBytes", "byte[]"),
+            new MethodSignature("java.util.random.RandomGenerator", "nextDouble"),
+            new MethodSignature("java.util.random.RandomGenerator", "nextFloat"),
+            new MethodSignature("java.util.random.RandomGenerator", "nextGaussian"),
+            new MethodSignature("java.util.random.RandomGenerator", "nextInt"),
+            new MethodSignature("java.util.random.RandomGenerator", "nextInt", "int"),
+            new MethodSignature("java.util.random.RandomGenerator", "nextLong")
     ));
 
     @Test public void sanity() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.EnumeratingWhitelist.MethodSignature;
@@ -125,7 +126,25 @@ public class StaticWhitelistTest {
             // Overrides CharSequence.isEmpty in Java 15+.
             new MethodSignature(String.class, "isEmpty", new Class<?>[0]),
             // Does not exist until Java 15.
-            new MethodSignature(CharSequence.class, "isEmpty", new Class<?>[0])
+            new MethodSignature(CharSequence.class, "isEmpty", new Class<?>[0]),
+            // Override the corresponding RandomGenerator methods in Java 17+.
+            new MethodSignature(Random.class, "nextBoolean", new Class<?>[0]),
+            new MethodSignature(Random.class, "nextBytes", new Class<?>[] {byte[].class}),
+            new MethodSignature(Random.class, "nextDouble", new Class<?>[0]),
+            new MethodSignature(Random.class, "nextFloat", new Class<?>[0]),
+            new MethodSignature(Random.class, "nextGaussian", new Class<?>[0]),
+            new MethodSignature(Random.class, "nextInt", new Class<?>[0]),
+            new MethodSignature(Random.class, "nextInt", new Class<?>[] {int.class}),
+            new MethodSignature(Random.class, "nextLong", new Class<?>[0]),
+            // Do not exist until Java 17.
+            new MethodSignature("java.util.random.RandomGenerator", "nextBoolean", new String[0]),
+            new MethodSignature("java.util.random.RandomGenerator", "nextBytes", new String[] {"byte[]"}),
+            new MethodSignature("java.util.random.RandomGenerator", "nextDouble", new String[0]),
+            new MethodSignature("java.util.random.RandomGenerator", "nextFloat", new String[0]),
+            new MethodSignature("java.util.random.RandomGenerator", "nextGaussian", new String[0]),
+            new MethodSignature("java.util.random.RandomGenerator", "nextInt", new String[0]),
+            new MethodSignature("java.util.random.RandomGenerator", "nextInt", new String[] {"int"}),
+            new MethodSignature("java.util.random.RandomGenerator", "nextLong", new String[0])
     ));
 
     @Test public void sanity() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
@@ -99,16 +99,14 @@ public class StaticWhitelistTest {
 
 
         for (EnumeratingWhitelist.Signature sig : sigs) {
+            if (KNOWN_GOOD_SIGNATURES.contains(sig)) {
+                continue;
+            }
             try {
                 assertTrue(sig + " does not exist (or is an override)", sig.exists());
-            } catch (AssertionError e) {
-                if (!KNOWN_GOOD_SIGNATURES.contains(sig)) {
-                    throw e;
-                }
             } catch (ClassNotFoundException x) {
-                if (!KNOWN_GOOD_SIGNATURES.contains(sig)) {
-                    throw new Exception("Unable to verify existence of " + sig, x);
-                }
+                // Wrapping exception to include the full signature in the error message.
+                throw new Exception("Unable to verify existence of " + sig, x);
             }
         }
     }


### PR DESCRIPTION
See [JENKINS-68070](https://issues.jenkins.io/browse/JENKINS-68070).

Java 15 added a new `CharSequence.isEmpty` default method. This breaks `StaticWhitelistTest` when running against Java 15+ because `String.isEmpty` becomes an override. It would also cause `RejectedAccessException` to be thrown for any sandboxed code that currently calls `String.isEmpty`.

This PR preemptively adds `CharSequence.isEmpty` to `generic-whitelist` so that everything should regardless of what Java version is being used.

I have not actually tested this against Java 15+ myself, so marking the PR as a draft.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
