### PR TITLE
Whitelist net.sf.json.JSON isEmpty()

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -825,6 +825,7 @@ staticMethod java.util.regex.Pattern quote java.lang.String
 method java.util.regex.Pattern split java.lang.CharSequence
 method java.util.regex.Pattern split java.lang.CharSequence int
 method net.sf.json.JSON isArray
+method net.sf.json.JSON isEmpty
 method net.sf.json.JSON size
 
 


### PR DESCRIPTION
While `size()` is whitelisted already, `isEmpty()` isn't.

-------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
