### PR TITLE
Optimize the display of ScriptApproval page

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
@@ -234,10 +234,12 @@ THE SOFTWARE.
                 </j:otherwise>
             </j:choose>
             <p>Signatures already approved:</p>
+            <br>
             <textarea readonly="readonly" id="approvedSignatures" rows="10" cols="80">
                 <j:forEach var="line" items="${it.approvedSignatures}">${line}<st:out value="&#10;"/></j:forEach>
             </textarea>
             <p>Signatures already approved assuming permission check:</p>
+            <br>
             <textarea readonly="readonly" id="aclApprovedSignatures" rows="10" cols="80">
                 <j:forEach var="line" items="${it.aclApprovedSignatures}">${line}<st:out value="&#10;"/></j:forEach>
             </textarea>

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
@@ -234,12 +234,12 @@ THE SOFTWARE.
                 </j:otherwise>
             </j:choose>
             <p>Signatures already approved:</p>
-            <br>
+            <br/>
             <textarea readonly="readonly" id="approvedSignatures" rows="10" cols="80">
                 <j:forEach var="line" items="${it.approvedSignatures}">${line}<st:out value="&#10;"/></j:forEach>
             </textarea>
             <p>Signatures already approved assuming permission check:</p>
-            <br>
+            <br/>
             <textarea readonly="readonly" id="aclApprovedSignatures" rows="10" cols="80">
                 <j:forEach var="line" items="${it.aclApprovedSignatures}">${line}<st:out value="&#10;"/></j:forEach>
             </textarea>


### PR DESCRIPTION
Optimize the display of ScriptApproval page.

The textarea actual display is dislocation.
![20220416152958](https://user-images.githubusercontent.com/18117854/163666267-cf481324-6fdb-40dc-989f-ee3798474dde.png)


After fix with br element.
![1650093684(1)](https://user-images.githubusercontent.com/18117854/163666016-a14fb1ce-cade-482e-9bb5-4cb554b29abd.jpg)

