### PR TITLE
Adapt generic-whitelist to handle addition of String#stripIndent method in Java 15

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -267,6 +267,7 @@ method java.lang.String split java.lang.String
 method java.lang.String split java.lang.String int
 method java.lang.String startsWith java.lang.String
 method java.lang.String startsWith java.lang.String int
+method java.lang.String stripIndent
 method java.lang.String substring int
 method java.lang.String substring int int
 method java.lang.String toCharArray

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
@@ -120,8 +120,9 @@ public class StaticWhitelistTest {
                     "java.util.Iterator", "groovy.lang.Closure"),
             // Overrides CharSequence.isEmpty in Java 15+.
             new MethodSignature(String.class, "isEmpty"),
-            // Does not exist until Java 15.
+            // Do not exist until Java 15.
             new MethodSignature(CharSequence.class, "isEmpty"),
+            new MethodSignature(String.class, "stripIndent"),
             // Override the corresponding RandomGenerator methods in Java 17+.
             new MethodSignature(Random.class, "nextBoolean"),
             new MethodSignature(Random.class, "nextBytes", byte[].class),


### PR DESCRIPTION
`stripIndent` eclipses the `DefaultGroovyMethods` which is already in the generic-whitelist.
Scripts already using this method were breaking when the JVM was upstepped as it would choose standard implementation over the one provided by groovy.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Looking at git history it is not clear to me if you require a jira ticket.  If so let me know the I create one.