### PR TITLE
[JENKINS-69899] Do not visit EmptyExpression when transforming fields declared using @Field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>groovy-sandbox</artifactId>
-      <version>1.31-rc227.549f6a_a_e591b_</version> <!-- TODO: https://github.com/jenkinsci/groovy-sandbox/pull/94 -->
+      <version>1.31</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>groovy-sandbox</artifactId>
-      <version>1.30</version>
+      <version>1.31-rc227.549f6a_a_e591b_</version> <!-- TODO: https://github.com/jenkinsci/groovy-sandbox/pull/94 -->
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.groovy</groupId>

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptor.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptor.java
@@ -418,7 +418,7 @@ final class SandboxInterceptor extends GroovyInterceptor {
                 Checker.preCheckedCast(field.getType(), value, false, false, false);
                 return super.onSetAttribute(invoker, receiver, attribute, value);
             } else {
-                throw StaticWhitelist.rejectField(field);
+                rejector = () -> StaticWhitelist.rejectField(field);
             }
         }
         if (receiver instanceof Class) {

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -1650,6 +1650,12 @@ public class SandboxInterceptorTest {
         assertEvaluate(new GenericWhitelist(), true, "('a' =~ '.*') as Boolean");
     }
 
+    @Test
+    public void staticAttributesAreNotShadowedByClassFields() throws Throwable {
+        assertEvaluate(new GenericWhitelist(), "foo", "class MyClass { static String name = 'foo' }; MyClass.@name");
+        assertEvaluate(new GenericWhitelist(), "foo", "class MyClass { static String name }; MyClass.@name = 'foo'");
+    }
+
     /**
      * Checks that the annotation is blocked from being used in the provided script whether it is imported or used via
      * fully-qualified class name.

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -911,6 +911,8 @@ public class SandboxInterceptorTest {
             // GroovyRuntimeException.
             if (x.getCause() instanceof RejectedAccessException) {
                 errors.checkThat(x.getMessage(), ((RejectedAccessException)x.getCause()).getSignature(), is(expectedSignature));
+            } else {
+                errors.addError(x);
             }
         } catch (RejectedAccessException x) {
             errors.checkThat(x.getMessage(), x.getSignature(), is(expectedSignature));


### PR DESCRIPTION
See [JENKINS-69899](https://issues.jenkins.io/browse/JENKINS-69899) and https://github.com/jenkinsci/groovy-sandbox/pull/94.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] ~Ensure you have provided tests - that demonstrates feature works or fixes the issue~ Tests are in groovy-sandbox

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
