### PR TITLE
Workaround for JDK-8231454 on Java 11 is no longer necessary as of 11.0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.332.1</jenkins.version>
+    <jenkins.version>2.346.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
   <licenses>
@@ -50,8 +50,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
-        <version>1289.v5c4b_1c43511b_</version>
+        <artifactId>bom-2.346.x</artifactId>
+        <version>1382.v7d694476f340</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
@@ -35,6 +35,7 @@ import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
+import hudson.util.VersionNumber;
 import io.jenkins.lib.versionnumber.JavaSpecificationVersion;
 
 import java.beans.Introspector;
@@ -269,9 +270,10 @@ public final class SecureGroovyScript extends AbstractDescribableImpl<SecureGroo
     }
 
     private static void cleanUpClassInfoCache(Class<?> clazz) {
-        JavaSpecificationVersion current = JavaSpecificationVersion.forCurrentJVM();
-        if (current.isNewerThan(new JavaSpecificationVersion("1.8"))
-                && current.isOlderThan(new JavaSpecificationVersion("16"))) {
+        int releaseVersion = JavaSpecificationVersion.forCurrentJVM().toReleaseVersion();
+        if ((releaseVersion > 8 && releaseVersion < 11)
+                || (releaseVersion == 11 && new VersionNumber(System.getProperty("java.version")).isOlderThan(new VersionNumber("11.0.17")))
+                || (releaseVersion > 11 && releaseVersion < 16)) {
             try {
                 // TODO Work around JDK-8231454.
                 Class<?> classInfoC = Class.forName("com.sun.beans.introspect.ClassInfo");


### PR DESCRIPTION
Applies the change from https://github.com/jenkinsci/workflow-cps-plugin/pull/600 to the copypasta in this plugin.