### PR TITLE
Override getCategory() instead of getCategoryName()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalLink.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalLink.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.scriptsecurity.scripts;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.ManagementLink;
 import hudson.security.Permission;
@@ -75,9 +76,9 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
         return Jenkins.ADMINISTER;
     }
 
-    // TODO: Override `getCategory` instead using `Category.SECURITY` when minimum core version is 2.226+, see https://github.com/jenkinsci/jenkins/commit/6de7e5fc7f6fb2e2e4cb342461788f97e3dfd8f6.
-    protected String getCategoryName() {
-        return "SECURITY";
+    @NonNull
+    @Override
+    public Category getCategory() {
+        return Category.SECURITY;
     }
-
 }


### PR DESCRIPTION
Jenkins baseline is > 2.226 already.

-----------------------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
