### PR TITLE
Add enum.valueOf signature to the whitelist

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -116,6 +116,7 @@ new java.lang.Boolean java.lang.String
 staticMethod java.lang.Boolean parseBoolean java.lang.String
 staticMethod java.lang.Boolean valueOf boolean
 staticMethod java.lang.Boolean valueOf java.lang.String
+staticMethod java.lang.Enum valueOf java.lang.Class java.lang.String
 method java.lang.CharSequence charAt int
 method java.lang.CharSequence isEmpty
 method java.lang.CharSequence length


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

This will whitelist the enum.valueOf signature. Currently, I'm having to use a workaround as follows:
```
for (Chores chore : Chores.values()) {
    if (chore.name() == bom.config.chore_type) {
        chore_type = chore
    }
}
```
instead of a simple: 
```
chore_type = Chores.valueOf(bom.config.chore_type)
``` 
