### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript/JENKINS-15604.js
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript/JENKINS-15604.js
@@ -1,5 +1,5 @@
 // https://issues.jenkins-ci.org/browse/JENKINS-15604 workaround:
 function cmChange(editor, change) {
     editor.save();
-    $$('.validated').each(function (e) {e.onchange();});
+    document.querySelectorAll('.validated').forEach(function (e) {e.onchange();});
 }

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
             <script>
                 var mgr = <st:bind value="${it}"/>;
                 function hideScript(hash) {
-                    $('ps-' + hash).remove();
+                    document.getElementById('ps-' + hash).remove();
                 }
                 function approveScript(hash) {
                     mgr.approveScript(hash);
@@ -41,13 +41,15 @@ THE SOFTWARE.
                     hideScript(hash);
                 }
                 function hideSignature(hash) {
-                    $('s-' + hash).style.display = 'none';
+                    document.getElementById('s-' + hash).style.display = 'none';
                 }
                 function updateApprovedSignatures(r) {
                     var both = r.responseObject();
-                    $('approvedSignatures').value = both[0].join('\n');
-                    $('aclApprovedSignatures').value = both[1].join('\n');
-                    $('dangerousApprovedSignatures').value = both[2].join('\n');
+                    document.getElementById('approvedSignatures').value = both[0].join('\n');
+                    document.getElementById('aclApprovedSignatures').value = both[1].join('\n');
+                    if (document.getElementById('dangerousApprovedSignatures')) {
+                        document.getElementById('dangerousApprovedSignatures').value = both[2].join('\n');
+                    }
                 }
                 function approveSignature(signature, hash) {
                     mgr.approveSignature(signature, function(r) {
@@ -78,12 +80,12 @@ THE SOFTWARE.
                 
                 function renderPendingClasspathEntries(pendingClasspathEntries) {
                     if (pendingClasspathEntries.length == 0) {
-                        $('pendingClasspathEntries-none').show();
-                        $('pendingClasspathEntries').childElements().each(function(e){e.remove()});
-                        $('pendingClasspathEntries').hide();
+                        document.getElementById('pendingClasspathEntries-none').style.display = '';
+                        Array.from(document.getElementById('pendingClasspathEntries').children).forEach(function(e){e.remove()});
+                        document.getElementById('pendingClasspathEntries').style.display = 'none';
                     } else {
-                        $('pendingClasspathEntries-none').hide();
-                        $('pendingClasspathEntries').childElements().each(function(e){e.remove()});
+                        document.getElementById('pendingClasspathEntries-none').style.display = 'none';
+                        Array.from(document.getElementById('pendingClasspathEntries').children).forEach(function(e){e.remove()});
                         /*
                            Create a list like:
                             <p id="pcp-${pcp.hash}">
@@ -92,39 +94,45 @@ THE SOFTWARE.
                                 ${pcp.hash} (${pcp.path})
                             </p>
                          */
-                        pendingClasspathEntries.each(function(e) {
-                            var block = new Element('p', { 'id': 'pcp-' + e.hash });
-                            var approveButton = new Element('button', { 'class': 'approve', 'hash': e.hash});
-                            approveButton.insert('Approve');
-                            approveButton.observe('click', function() {
-                                approveClasspathEntry(this.readAttribute('hash'));
+                        pendingClasspathEntries.forEach(function(e) {
+                            var block = document.createElement('p');
+                            block.setAttribute('id', 'pcp-' + e.hash);
+                            var approveButton = document.createElement('button');
+                            approveButton.setAttribute('class', 'approve');
+                            approveButton.setAttribute('hash', e.hash);
+                            approveButton.textContent = 'Approve';
+                            approveButton.addEventListener('click', function() {
+                                approveClasspathEntry(this.getAttribute('hash'));
                             });
-                            var denyButton = new Element('button', { 'class': 'deny', 'hash': e.hash});
-                            denyButton.insert('Deny');
-                            denyButton.observe('click', function() {
-                                denyClasspathEntry(this.readAttribute('hash'));
+                            var denyButton = document.createElement('button');
+                            denyButton.setAttribute('class', 'deny');
+                            denyButton.setAttribute('hash', e.hash);
+                            denyButton.textContent = 'Deny';
+                            denyButton.addEventListener('click', function() {
+                                denyClasspathEntry(this.getAttribute('hash'));
                             });
-                            block.insert(approveButton);
-                            block.insert(denyButton);
-                            var code = new Element('code', { 'title': e.hash });
+                            block.appendChild(approveButton);
+                            block.appendChild(denyButton);
+                            var code = document.createElement('code');
+                            code.setAttribute('title', e.hash);
                             code.textContent = e.path;
-                            block.insert(code);
+                            block.appendChild(code);
                             
-                            $('pendingClasspathEntries').insert(block);
+                            document.getElementById('pendingClasspathEntries').appendChild(block);
                         });
-                        $('pendingClasspathEntries').show();
+                        document.getElementById('pendingClasspathEntries').style.display = '';
                     }
                 }
                 
                 function renderApprovedClasspathEntries(approvedClasspathEntries) {
                     if (approvedClasspathEntries.length == 0) {
-                        $('approvedClasspathEntries-none').show();
-                        $('approvedClasspathEntries').childElements().each(function(e){e.remove()});
-                        $('approvedClasspathEntries').hide();
-                        $('approvedClasspathEntries-clear').hide();
+                        document.getElementById('approvedClasspathEntries-none').style.display = '';
+                        Array.from(document.getElementById('approvedClasspathEntries').children).forEach(function(e){e.remove()});
+                        document.getElementById('approvedClasspathEntries').style.display = 'none';
+                        document.getElementById('approvedClasspathEntries-clear').style.display = 'none';
                     } else {
-                        $('approvedClasspathEntries-none').hide();
-                        $('approvedClasspathEntries').childElements().each(function(e){e.remove()});
+                        document.getElementById('approvedClasspathEntries-none').style.display = 'none';
+                        Array.from(document.getElementById('approvedClasspathEntries').children).forEach(function(e){e.remove()});
                         /*
                            Create a list like:
                             <p id="acp-${acp.hash}">
@@ -132,24 +140,28 @@ THE SOFTWARE.
                                 ${acp.hash} (${acp.path})
                             </p>
                          */
-                        approvedClasspathEntries.each(function(e) {
-                            var block = new Element('p', { 'id': 'acp-' + e.hash });
-                            var deleteButton = new Element('button', { 'class': 'delete', 'hash': e.hash});
-                            deleteButton.insert('Delete');
-                            deleteButton.observe('click', function() {
+                        approvedClasspathEntries.forEach(function(e) {
+                            var block = document.createElement('p');
+                            block.setAttribute('id', 'acp-' + e.hash);
+                            var deleteButton = document.createElement('button');
+                            deleteButton.setAttribute('class', 'delete');
+                            deleteButton.setAttribute('hash', e.hash);
+                            deleteButton.textContent = 'Delete';
+                            deleteButton.addEventListener('click', function() {
                                 if (confirm('Really delete this approved classpath entry? Any existing scripts using it will need to be rerun and the entry reapproved.')) {
-                                    denyApprovedClasspathEntry(this.readAttribute('hash'));
+                                    denyApprovedClasspathEntry(this.getAttribute('hash'));
                                 }
                             });
-                            block.insert(deleteButton);
-                            var code = new Element('code', { 'title': e.hash });
+                            block.appendChild(deleteButton);
+                            var code = document.createElement('code');
+                            code.setAttribute('title', e.hash);
                             code.textContent = e.path;
-                            block.insert(code);
+                            block.appendChild(code);
                             
-                            $('approvedClasspathEntries').insert(block);
+                            document.getElementById('approvedClasspathEntries').appendChild(block);
                         });
-                        $('approvedClasspathEntries').show();
-                        $('approvedClasspathEntries-clear').show();
+                        document.getElementById('approvedClasspathEntries').style.display = '';
+                        document.getElementById('approvedClasspathEntries-clear').style.display = '';
                     }
                 }
                 
@@ -179,7 +191,7 @@ THE SOFTWARE.
                     });
                 }
                 
-                Event.observe(window, "load", function(){
+                window.addEventListener("load", function(){
                     mgr.getClasspathRenderInfo(function(r) {
                         renderClasspaths(r);
                     });
@@ -206,7 +218,7 @@ THE SOFTWARE.
             <j:if test="${it.hasDeprecatedApprovedScriptHashes()}">
                 <p id="deprecated-approvedScripts-clear">
                     You have <st:out value="${it.countDeprecatedApprovedScriptHashes()}"/> script approvals with deprecated hashes:
-                    <button onclick="if (confirm('Really delete all deprecated approvals? Any existing scripts will need to be requeued and reapproved.')) {mgr.clearDeprecatedApprovedScripts(); $('deprecated-approvedScripts-clear').hide();}">Clear Deprecated Approvals</button>
+                    <button onclick="if (confirm('Really delete all deprecated approvals? Any existing scripts will need to be requeued and reapproved.')) {mgr.clearDeprecatedApprovedScripts(); document.getElementById('deprecated-approvedScripts-clear').style.display = 'none';}">Clear Deprecated Approvals</button>
                 </p>
                 <p class="setting-description">
                     Script approvals are stored in Jenkins as the hashed value of the script. Old approvals were hashed using SHA-1, which is deprecated.
@@ -286,7 +298,7 @@ THE SOFTWARE.
                 <p id="deprecated-approvedClasspaths-clear">
                     You have ${it.countDeprecatedApprovedClasspathHashes()} approved classpath entries with deprecated hashes:
                     <span id="deprecated-approvedClasspaths-clear-btn">
-                        <button onclick="if (confirm('This will be scheduled on a background thread. You can follow the progress in the system log')) {mgr.convertDeprecatedApprovedClasspathEntries(); $('deprecated-approvedClasspaths-clear-btn').hide(); $('deprecated-approvedClasspaths-clear-spinner').show();}">Rehash Deprecated Approvals</button>
+                        <button onclick="if (confirm('This will be scheduled on a background thread. You can follow the progress in the system log')) {mgr.convertDeprecatedApprovedClasspathEntries(); document.getElementById('deprecated-approvedClasspaths-clear-btn').style.display = 'none'; document.getElementById('deprecated-approvedClasspaths-clear-spinner').style.display = '';}">Rehash Deprecated Approvals</button>
                     </span>
                     <span id="deprecated-approvedClasspaths-clear-spinner">
                         <l:icon alt="${%Converting...}" class="${it.spinnerIconClassName} icon-md"/>
@@ -300,14 +312,14 @@ THE SOFTWARE.
                 <j:choose>
                     <j:when test="${it.isConvertingDeprecatedApprovedClasspathEntries()}">
                         <script>
-                            $('deprecated-approvedClasspaths-clear-btn').hide();
-                            $('deprecated-approvedClasspaths-clear-spinner').show();
+                            document.getElementById('deprecated-approvedClasspaths-clear-btn').style.display = 'none';
+                            document.getElementById('deprecated-approvedClasspaths-clear-spinner').style.display = '';
                         </script>
                     </j:when>
                     <j:otherwise>
                         <script>
-                            $('deprecated-approvedClasspaths-clear-btn').show();
-                            $('deprecated-approvedClasspaths-clear-spinner').hide();
+                            document.getElementById('deprecated-approvedClasspaths-clear-btn').style.display = '';
+                            document.getElementById('deprecated-approvedClasspaths-clear-spinner').style.display = 'none';
                         </script>
                     </j:otherwise>
                 </j:choose>


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I installed this plugin on a custom build of Jenkins that had Prototype ripped out (a local project branch), loaded the script approval page in the UI, and approved/denied both signatures and classpath entries. I had the Script Console open and observed no exceptions being thrown.