### PR TITLE
Add proper support for propertyMissing setter and getter

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SandboxInterceptorTest.java
@@ -338,6 +338,27 @@ public class SandboxInterceptorTest {
         }
     }
 
+    @Test public void propertyMissingMethods() throws Exception {
+        String clazz = PropertyMissing.class.getName();
+        String ctor = "new " + clazz;
+        String getPM = "method " + clazz + " propertyMissing java.lang.String";
+        String setPM = "method " + clazz + " propertyMissing java.lang.String java.lang.Object";
+        String script = "def d = new " + clazz + "(); d.prop = 'val'; d.prop";
+        assertEvaluate(new StaticWhitelist(ctor, getPM, setPM), "val", script);
+        assertRejected(new StaticWhitelist(ctor, setPM), getPM, script);
+        assertRejected(new StaticWhitelist(ctor), setPM, script);
+    }
+
+    public static final class PropertyMissing {
+        private final Map<String,Object> values = new HashMap<>();
+        public Object propertyMissing(String n) {
+            return values.get(n);
+        }
+        public void propertyMissing(String n, Object v) {
+            values.put(n, v);
+        }
+    }
+
     @Test public void mapProperties() throws Exception {
         assertEvaluate(new GenericWhitelist(), 42, "def m = [:]; m.answer = 42; m.answer");
     }


### PR DESCRIPTION
85d16bd broke the setter version of propertyMissing method. Previously, Groovys synthetic setProperty() method looked for propertyMissing() methods and called it if it was defined. After 85d16bd this is no longer supported since calls to the synthetic version of setProperty() is prohibited.

This commit addresses this issue by explicitly checking for propertyMissing() methods, both in the set and get cases.

### Testing done

I've added a unit test testing the new functionality. It is heavily inspired by setProperty/getProperty since the functionality is very similar. I've also manually verified that it works with "real" Jenkins pipeline in sandbox mode.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```