### PR TITLE
Separate script creation from approval.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 target
 work
-
+/.classpath
+/.project
+/.settings/
 .idea
 *.iml
 .*.sw*

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -95,6 +95,10 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
     public static /* non-final */ boolean ADMIN_AUTO_APPROVAL_ENABLED =
             SystemProperties.getBoolean(ScriptApproval.class.getName() + ".ADMIN_AUTO_APPROVAL_ENABLED");
 
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
+    public static /* non-final */ boolean ALLOW_ADMIN_APPROVAL_ON_SAVE_ENABLED =
+            SystemProperties.getBoolean(ScriptApproval.class.getName() + ".ALLOW_ADMIN_APPROVAL_ON_SAVE_ENABLED");
+
     private static final Logger LOG = Logger.getLogger(ScriptApproval.class.getName());
 
     private static final XStream2 XSTREAM2 = new XStream2();
@@ -592,7 +596,7 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
     public synchronized String configuring(@NonNull String script, @NonNull Language language, @NonNull ApprovalContext context, boolean approveIfAdmin) {
         final ConversionCheckResult result = checkAndConvertApprovedScript(script, language);
         if (!result.approved) {
-            if (!Jenkins.get().isUseSecurity() || 
+            if (!Jenkins.get().isUseSecurity() || ALLOW_ADMIN_APPROVAL_ON_SAVE_ENABLED &&
                     ((Jenkins.getAuthentication2() != ACL.SYSTEM2 && Jenkins.get().hasPermission(Jenkins.ADMINISTER))
                             && (ADMIN_AUTO_APPROVAL_ENABLED || approveIfAdmin))) {
                 approvedScriptHashes.add(result.newHash);


### PR DESCRIPTION
Many organisations require a separation between the creation of a script and the approval of a script, possibly for regulatory reasons.

This change makes the approval of a non sandboxed script distinct from the saving of a job that has that script, so regulatory processes can be followed.

<!-- Please describe your pull request here. -->

### Testing done

None yet other than adapting tests - draft until manual testing has been performed.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
