### PR TITLE
[JENKINS-71808] `GenericWhitelistTest#sanity` fails on Java 21

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.regex.Matcher;
 
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.EnumeratingWhitelist.MethodSignature;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.EnumeratingWhitelist.Signature;
@@ -140,7 +141,11 @@ public class StaticWhitelistTest {
             new MethodSignature("java.util.random.RandomGenerator", "nextGaussian"),
             new MethodSignature("java.util.random.RandomGenerator", "nextInt"),
             new MethodSignature("java.util.random.RandomGenerator", "nextInt", "int"),
-            new MethodSignature("java.util.random.RandomGenerator", "nextLong")
+            new MethodSignature("java.util.random.RandomGenerator", "nextLong"),
+            // Override the corresponding MatchResult methods in Java 20+.
+            new MethodSignature(Matcher.class, "end", String.class),
+            new MethodSignature(Matcher.class, "group", String.class),
+            new MethodSignature(Matcher.class, "start", String.class)
     ));
 
     @Test public void sanity() throws Exception {


### PR DESCRIPTION
See [JENKINS-71808](https://issues.jenkins.io/browse/JENKINS-71808). This test starts failing on Java 20 due to the default methods added in [JDK-8065554](https://bugs.openjdk.org/browse/JDK-8065554) / https://github.com/openjdk/jdk/pull/10000. This PR adapts the tests in a similar manner to the work done for Java 17.

### Testing done

Ran the tests on Java 11, 17, and 21. Before this PR, Java 21 failed. After this PR, all Java versions are passing.