### PR TITLE
Add break tag in ScriptSecurity plugin page

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval/index.jelly
@@ -269,6 +269,7 @@ THE SOFTWARE.
             <j:set var="dangerousApprovedSignatures" value="${it.dangerousApprovedSignatures}"/>
             <j:if test="${!empty(dangerousApprovedSignatures)}">
                 <p>Signatures already approved which <strong><font color="red">may have introduced a security vulnerability</font></strong> (recommend clearing):</p>
+                <br/>
                 <textarea readonly="readonly" id="dangerousApprovedSignatures" rows="10" cols="80">
                     <j:forEach var="line" items="${dangerousApprovedSignatures}">${line}<st:out value="&#10;"/></j:forEach>
                 </textarea>


### PR DESCRIPTION
Resolves: https://issues.jenkins.io/browse/JENKINS-72264

### Testing done
There is no need for test it because this is very simple issue - just adding missing BR tag between 271 and 272 lines - according to https://issues.jenkins.io/browse/JENKINS-72264 -> description and last comment of @MarkEWaite.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue