### PR TITLE
Fix reloading configuration from disk

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -534,12 +534,15 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
             save();
         }
         // only call on subsequent load to avoid cycle
-        if (Jenkins.get().getInitLevel().compareTo(InitMilestone.COMPLETED) > 0) {
+        if (Jenkins.get().getInitLevel() == InitMilestone.COMPLETED) {
             try {
+                LOG.log(Level.FINE, "Reconfiguring ScriptApproval after loading configuration from disk");
                 reconfigure();
             } catch (IOException e) {
                 LOG.log(Level.WARNING, e, () -> "Failed to reconfigure ScriptApproval");
             }
+        } else {
+            LOG.log(Level.FINE, "Skipping reconfiguration of ScriptApproval during Jenkins startup sequence");
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.scriptsecurity.scripts;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.init.InitMilestone;
 import hudson.model.BallColor;
 import hudson.model.PageDecorator;
 import hudson.security.ACLContext;
@@ -268,7 +269,7 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
     /** All external classpath entries allowed used for scripts. */
     private /*final*/ TreeSet<ApprovedClasspathEntry> approvedClasspathEntries;
 
-    /* for test */ void addApprovedClasspathEntry(ApprovedClasspathEntry acp) {
+    /* for test */ synchronized void addApprovedClasspathEntry(ApprovedClasspathEntry acp) {
         approvedClasspathEntries.add(acp);
     }
 
@@ -503,16 +504,12 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
     @DataBoundConstructor
     public ScriptApproval() {
         load();
-        /* can be null when upgraded from old versions.*/
-        if (aclApprovedSignatures == null) {
-            aclApprovedSignatures = new TreeSet<>();
-        }
-        if (approvedClasspathEntries == null) {
-            approvedClasspathEntries = new TreeSet<>();
-        }
-        if (pendingClasspathEntries == null) {
-            pendingClasspathEntries = new TreeSet<>();
-        }
+    }
+
+    @Override
+    public synchronized void load() {
+        clear();
+        super.load();
         // Check for loaded class directories
         boolean changed = false;
         int dcp = 0;
@@ -535,6 +532,37 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
         }
         if (changed) {
             save();
+        }
+        // only call on subsequent load to avoid cycle
+        if (Jenkins.get().getInitLevel().compareTo(InitMilestone.COMPLETED) > 0) {
+            try {
+                reconfigure();
+            } catch (IOException e) {
+                LOG.log(Level.WARNING, e, () -> "Failed to reconfigure ScriptApproval");
+            }
+        }
+    }
+
+    private void clear() {
+        approvedScriptHashes.clear();
+        approvedSignatures.clear();
+        pendingScripts.clear();
+        pendingSignatures.clear();
+        /* can be null when upgraded from old versions.*/
+        if (aclApprovedSignatures == null) {
+            aclApprovedSignatures = new TreeSet<>();
+        } else {
+            aclApprovedSignatures.clear();
+        }
+        if (approvedClasspathEntries == null) {
+            approvedClasspathEntries = new TreeSet<>();
+        } else {
+            approvedClasspathEntries.clear();
+        }
+        if (pendingClasspathEntries == null) {
+            pendingClasspathEntries = new TreeSet<>();
+        } else {
+            pendingClasspathEntries.clear();
         }
     }
 
@@ -571,7 +599,7 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
     }
 
     /** Nothing has ever been approved or is pending. */
-    boolean isEmpty() {
+    synchronized boolean isEmpty() {
         return approvedScriptHashes.isEmpty() &&
                approvedSignatures.isEmpty() &&
                aclApprovedSignatures.isEmpty() &&
@@ -1198,7 +1226,7 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
 
     @Restricted(NoExternalUse.class) // for use from AJAX
     @JavaScriptMethod
-    public JSON approveClasspathEntry(String hash) throws IOException {
+    public synchronized JSON approveClasspathEntry(String hash) throws IOException {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         URL url = null;
         synchronized (this) {
@@ -1222,7 +1250,7 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
 
     @Restricted(NoExternalUse.class) // for use from AJAX
     @JavaScriptMethod
-    public JSON denyClasspathEntry(String hash) throws IOException {
+    public synchronized JSON denyClasspathEntry(String hash) throws IOException {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         PendingClasspathEntry cp = getPendingClasspathEntry(hash);
         if (cp != null) {
@@ -1234,7 +1262,7 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
 
     @Restricted(NoExternalUse.class) // for use from AJAX
     @JavaScriptMethod
-    public JSON denyApprovedClasspathEntry(String hash) throws IOException {
+    public synchronized JSON denyApprovedClasspathEntry(String hash) throws IOException {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         if (approvedClasspathEntries.remove(new ApprovedClasspathEntry(hash, null))) {
             save();

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/HasherScriptApprovalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/HasherScriptApprovalTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -51,7 +52,7 @@ public class HasherScriptApprovalTest {
         session.then(r -> {
             final ScriptApproval approval = ScriptApproval.get();
             assertEquals(2, approval.countDeprecatedApprovedScriptHashes());
-            assertThat(log.getMessages(), containsInAnyOrder(
+            assertThat(log.getMessages(), hasItem(
                     containsString("There are 2 deprecated approved script hashes " +
                             "and 0 deprecated approved classpath hashes.")));
             approval.clearDeprecatedApprovedScripts();
@@ -102,7 +103,7 @@ public class HasherScriptApprovalTest {
             final ScriptApproval approval = ScriptApproval.get();
             assertEquals(2, approval.countDeprecatedApprovedClasspathHashes());
 
-            assertThat(log.getMessages(), containsInAnyOrder(
+            assertThat(log.getMessages(), hasItem(
                     containsString("There are 0 deprecated approved script hashes " +
                             "and 2 deprecated approved classpath hashes.")));
 

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/HasherScriptApprovalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/HasherScriptApprovalTest.java
@@ -15,7 +15,6 @@ import java.net.URL;
 import java.util.logging.Level;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;

--- a/src/test/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest/reload/scriptApproval.xml
+++ b/src/test/resources/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest/reload/scriptApproval.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<scriptApproval plugin="script-security@1.24">
+  <approvedScriptHashes>
+    <string>fccae58c5762bdd15daca97318e9d74333203106</string>
+  </approvedScriptHashes>
+  <approvedSignatures>
+    <string>staticMethod jenkins.model.Jenkins getInstance</string>
+  </approvedSignatures>
+  <aclApprovedSignatures/>
+  <approvedClasspathEntries/>
+  <pendingScripts/>
+  <pendingSignatures/>
+  <pendingClasspathEntries/>
+</scriptApproval>


### PR DESCRIPTION
This makes the `load()` method work properly when called after startup, in case of a reload configuration from disk for example.

Functionally, the `reconfigure()` method needs to be called implicitly when calling `load()`, because it updates a snapshot state that is used by running builds. If the persisted state has changed on disk then loaded, the snapshot needs to be updated accordingly.

Without this patch, the `ScriptApproval` state is correct, but anything that has changed since last time it was loaded is not reflected on running builds.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
