### PR TITLE
fix: auto re-request approval once dismissed [JENKINS-63668]

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -641,7 +641,10 @@ public class ScriptApproval extends GlobalConfiguration implements RootAction {
         }
         ConversionCheckResult result = checkAndConvertApprovedScript(script, language);
         if (!result.approved) {
-            // Probably need not add to pendingScripts, since generally that would have happened already in configuring.
+            // Usually. this method is called once the job configuration with the script is saved.
+            // If a script was previously pending and is now deleted, however, it would require to re-configure the job.
+            // That's why we call it again if it is unapproved in a running job.
+            this.configuring(script, language, ApprovalContext.create(), false);
             throw new UnapprovedUsageException(result.newHash);
         }
         return script;

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
@@ -51,7 +51,11 @@ import java.util.logging.Level;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ScriptApprovalTest extends AbstractApprovalTest<ScriptApprovalTest.Script> {
@@ -64,6 +68,41 @@ public class ScriptApprovalTest extends AbstractApprovalTest<ScriptApprovalTest.
 
     private static final String WHITELISTED_SIGNATURE = "method java.lang.String trim";
     private static final String DANGEROUS_SIGNATURE = "staticMethod hudson.model.User current";
+
+    private String approveIfExists(String script, ScriptApproval sa) throws IOException {
+        for (ScriptApproval.PendingScript pending : sa.getPendingScripts()) {
+            if(pending.script.equals(script)) {
+                String hash = pending.getHash();
+                sa.approveScript(hash);
+                return hash;
+            }
+        }
+        return null;
+    }
+
+    @Test
+    public void reapprovingShouldFail() throws Exception {
+        configureSecurity();
+        final ScriptApproval sa = ScriptApproval.get();
+        FreeStyleProject p = r.createFreeStyleProject();
+        String testScript = "jenkins.model.Jenkins.instance";
+        p.getPublishersList().add(new TestGroovyRecorder(
+                new SecureGroovyScript(testScript, false, null)));
+
+        String approvedHash = approveIfExists(testScript, sa);
+        assertNotNull(approvedHash);
+        r.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
+
+        sa.denyScript(approvedHash);
+
+        /*
+            * The script is not approved but should be pending.
+         */
+        r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
+        approvedHash = approveIfExists(testScript, sa);
+        assertNotNull(approvedHash);
+        r.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
+    }
 
     @Test public void emptyScript() throws Exception {
         configureSecurity();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR resolves JENKINS-63668. If a job fails because a script is not approved, it automatically re-requests the approval.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
