### PR TITLE
Skip `ScriptApprovalLoadingTest` in PCT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
     <changelist>999999-SNAPSHOT</changelist>
     <jenkins.version>2.387.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <!-- TODO until in parent -->
+    <jenkins-test-harness.version>2146.v6b_f8b_1cb_d12d</jenkins-test-harness.version>
   </properties>
   <licenses>
     <license>

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalLoadingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalLoadingTest.java
@@ -25,9 +25,11 @@
 package org.jenkinsci.plugins.scriptsecurity.scripts;
 
 import java.io.File;
+import jenkins.RestartRequiredException;
 import org.apache.commons.io.FileUtils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
+import org.junit.AssumptionViolatedException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -51,7 +53,11 @@ public final class ScriptApprovalLoadingTest {
     private static void _dynamicLoading2(JenkinsRule r) throws Throwable {
         File plugin = new File(r.jenkins.root, "plugins/script-security.jpl");
         FileUtils.copyFile(new File(plugin + ".bak"), plugin);
-        r.jenkins.pluginManager.dynamicLoad(plugin);
+        try {
+            r.jenkins.pluginManager.dynamicLoad(plugin);
+        } catch (RestartRequiredException x) {
+            throw new AssumptionViolatedException("perhaps running in PCT, where this cannot be tested", x);
+        }
         ScriptApproval sa = ScriptApproval.get();
         sa.approveSignature("method java.lang.Object wait");
         assertThat(sa.getApprovedSignatures(), arrayContaining("method java.lang.Object wait"));


### PR DESCRIPTION
https://github.com/jenkinsci/bom/issues/2805, amending #552. At least when `jth.jenkins-war.path` is defined (unnecessary for @cloudbees PCT which does not use this flag).