### PR TITLE
Avoid race condition in `ApprovedWhitelist` reconfiguration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,4 @@ if (env.CHANGE_ID == null) { // TODO https://github.com/jenkinsci/script-securit
 buildPlugin(
   useContainerAgent: true,
   configurations: configurations
-])
+)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 configurations = [[platform: 'linux', jdk: 21]]
-if (env.CHANGE_ID == null) { // TODO https://github.com/jenkinsci/script-security-plugin/pull/555 workaround
+if (env.CHANGE_ID == null) { // TODO https://github.com/jenkins-infra/helpdesk/issues/3931 workaround
   configurations += [platform: 'windows', jdk: 17]
 }
 buildPlugin(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,8 @@
+configurations = [[platform: 'linux', jdk: 21]]
+if (env.CHANGE_ID == null) { // TODO https://github.com/jenkinsci/script-security-plugin/pull/555 workaround
+  configurations += [platform: 'windows', jdk: 17]
+}
 buildPlugin(
   useContainerAgent: true,
-  configurations: [
-    [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+  configurations: configurations
 ])

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItemInArray;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
@@ -57,7 +58,7 @@ import static org.junit.Assert.fail;
 
 public class ScriptApprovalTest extends AbstractApprovalTest<ScriptApprovalTest.Script> {
     @Rule
-    public LoggerRule logging = new LoggerRule();
+    public LoggerRule logging = new LoggerRule().record(ScriptApproval.class, Level.FINER).capture(100);
 
     private static final String CLEAR_ALL_ID = "approvedScripts-clear";
 
@@ -75,11 +76,9 @@ public class ScriptApprovalTest extends AbstractApprovalTest<ScriptApprovalTest.
     @Test
     @LocalData("malformedScriptApproval")
     public void malformedScriptApproval() throws Exception {
-        logging.record(ScriptApproval.class, Level.FINER).capture(100);
         assertThat(Whitelist.all().permitsMethod(Jenkins.class.getMethod("get"), null, null), is(false));
-        assertThat(logging.getRecords(), Matchers.hasSize(Matchers.equalTo(1)));
-        assertEquals("Malformed signature entry in scriptApproval.xml: ' new java.lang.Exception java.lang.String'",
-                logging.getRecords().get(0).getMessage());
+        assertThat(logging.getRecords().stream().map(r -> r.getMessage()).toArray(String[]::new),
+            hasItemInArray("Malformed signature entry in scriptApproval.xml: ' new java.lang.Exception java.lang.String'"));
     }
 
     @Test @LocalData("dangerousApproved") public void dangerousApprovedSignatures() {


### PR DESCRIPTION
https://github.com/jenkinsci/script-security-plugin/pull/549#discussion_r1439742106 apparently can cause a functional test flake in CloudBees CI where a signature is approved and then two builds requiring that signature are started nearly simultaneously; sometimes one of them misses the update. Was trying to avoid a lock here but I do not see how.