### PR TITLE
Skip malformed whitelist entries

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelist.java
@@ -85,14 +85,22 @@ public final class StaticWhitelist extends EnumeratingWhitelist {
         while ((line = br.readLine()) != null) {
             line = filter(line);
             if (line != null) {
-                add(line);
+                try {
+                    add(line);
+                } catch (IOException x) {
+                    // Failed to parse line, ignore it and continue with the rest
+                }
             }
         }
     }
 
     public StaticWhitelist(Collection<? extends String> lines) throws IOException {
         for (String line : lines) {
-            add(line);
+            try {
+                add(line);
+            } catch (IOException x) {
+                // Failed to parse line, ignore it and continue with the rest
+            }
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
@@ -152,4 +152,7 @@ public class StaticWhitelistTest {
         sanity(StaticWhitelist.class.getResource("blacklist"));
     }
 
+    @Test public void malformed() throws Exception {
+        StaticWhitelist.from(StaticWhitelist.class.getResource("malformed-list"));
+    }
 }

--- a/src/test/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/malformed-list
+++ b/src/test/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/malformed-list
@@ -1,0 +1,16 @@
+# Malformed entry
+java.lang.temporal.Temporal
+
+# Groovy:
+staticMethod groovy.json.JsonOutput prettyPrint java.lang.String
+staticMethod groovy.json.JsonOutput toJson java.lang.Boolean
+staticMethod groovy.json.JsonOutput toJson java.lang.Character
+staticMethod groovy.json.JsonOutput toJson java.lang.Number
+staticMethod groovy.json.JsonOutput toJson java.lang.String
+staticMethod groovy.json.JsonOutput toJson java.net.URL
+staticMethod groovy.json.JsonOutput toJson java.util.Calendar
+staticMethod groovy.json.JsonOutput toJson java.util.Date
+staticMethod groovy.json.JsonOutput toJson java.util.Map
+staticMethod groovy.json.JsonOutput toJson java.util.UUID
+new groovy.json.JsonSlurper
+method groovy.json.JsonSlurper parseText java.lang.String


### PR DESCRIPTION
We are using Jenkins at scale at Intuit, and sometimes, a malformed entry gets added to the list of methods in the script approval, especially in the `scriptApproval.xml`. We are still investigating how a malformed entry could get added to that file.

In our case, the malformed entry was one without a prefix like this:
```xml
<?xml version='1.1' encoding='UTF-8'?>
<scriptApproval plugin="script-security@1251.vfe552ed55f8d">
  ...
  <approvedSignatures>
    <string>java.lang.temporal.Temporal</string>
    <string>method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object</string>
    <string>method hudson.FilePath copyFrom hudson.FilePath</string>
    <string>method hudson.FilePath delete</string>
    ...
  </approvedSignatures>
  ...
</scriptApproval>
```

The `java.lang.temporal.Temporal` caused an exception to be thrown and bubble all the way up without getting caught.
In that scenario, the list is ignored, and no methods are actually approved, causing the builds to fail over and over, despite getting approved in the UI.

The exception in Jenkins looks like this (note that we are using the `1251.vfe552ed55f8d` tag):
```
2024-02-08 09:31:00.353+0000 [id=7531]	WARNING	o.e.j.s.h.ContextHandler$Context#log: Error while serving https://redacted.com/growth/$stapler/bound/2239948b-8cca-43da-96e2-54b5ae176301/approveSignature
java.io.IOException: java.time.temporal.Temporal
	at org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist.parse(StaticWhitelist.java:171)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist.add(StaticWhitelist.java:187)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist.<init>(StaticWhitelist.java:91)
	at org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval$ApprovedWhitelist.reconfigure(ScriptApproval.java:946)
	at org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval.reconfigure(ScriptApproval.java:1091)
	at org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval.approveSignature(ScriptApproval.java:1103)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:710)
	at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:397)
Caused: java.lang.reflect.InvocationTargetException
	at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:401)
	at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:409)
	at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:207)
```

### What has been done

In order to make the plugin more resilient, I've wrapped the `StaticWhitelist.add(line)` calls into a try/catch block and silently ignore the error so that the loop can continue with the remaining entries.
I haven't seen any logger so I didn't add logging.

There are no changes to the frontend, only to the backend.

### Testing done

I've added a unit test to validate that the processing of a list with malformed entries doesn't fail.


```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
