### PR TITLE
Add Javadoc for system property escape hatches

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -100,7 +100,7 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
      *     This flag restores the previous behavior when set to {@code true}.
      * </p>
      *
-     * @link <a href="https://github.com/jenkinsci/script-security-plugin/releases/tag/1172.v35f6a_0b_8207e">1172.v35f6a_0b_8207e changelog</a>
+     * @see <a href="https://github.com/jenkinsci/script-security-plugin/releases/tag/1172.v35f6a_0b_8207e">1172.v35f6a_0b_8207e changelog</a>
      */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
     public static /* non-final */ boolean ADMIN_AUTO_APPROVAL_ENABLED =
@@ -113,7 +113,7 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
      *     This flag restores the previous behavior when set to {@code true}.
      * </p>
      *
-     * @link <a href="https://github.com/jenkinsci/script-security-plugin/releases/tag/1265.va_fb_290b_4b_d34">1265.va_fb_290b_4b_d34 changelog</a>
+     * @see <a href="https://github.com/jenkinsci/script-security-plugin/releases/tag/1265.va_fb_290b_4b_d34">1265.va_fb_290b_4b_d34 changelog</a>
      */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
     public static /* non-final */ boolean ALLOW_ADMIN_APPROVAL_ENABLED =

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -93,10 +93,28 @@ import org.kohsuke.stapler.verb.POST;
 @Extension
 public final class ScriptApproval extends GlobalConfiguration implements RootAction {
 
+    /**
+     * SECURITY-2450: Since 1172.v35f6a_0b_8207e, unmodified, unsandboxed scripts are no longer automatically approved
+     * when administrators submit job configuration forms.
+     * <p>
+     *     This flag restores the previous behavior when set to {@code true}.
+     * </p>
+     *
+     * @link <a href="https://github.com/jenkinsci/script-security-plugin/releases/tag/1172.v35f6a_0b_8207e">1172.v35f6a_0b_8207e changelog</a>
+     */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
     public static /* non-final */ boolean ADMIN_AUTO_APPROVAL_ENABLED =
             SystemProperties.getBoolean(ScriptApproval.class.getName() + ".ADMIN_AUTO_APPROVAL_ENABLED");
 
+    /**
+     * SECURITY-3103: Since 1265.va_fb_290b_4b_d34, administrators saving jobs (e.g., when copying existing jobs with
+     * unapproved scripts) will no longer result in unapproved scripts in those configurations being approved.
+     * <p>
+     *     This flag restores the previous behavior when set to {@code true}.
+     * </p>
+     *
+     * @link <a href="https://github.com/jenkinsci/script-security-plugin/releases/tag/1265.va_fb_290b_4b_d34">1265.va_fb_290b_4b_d34 changelog</a>
+     */
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "for script console")
     public static /* non-final */ boolean ALLOW_ADMIN_APPROVAL_ENABLED =
             SystemProperties.getBoolean(ScriptApproval.class.getName() + ".ALLOW_ADMIN_APPROVAL_ENABLED");


### PR DESCRIPTION
When playing with these options recently I had some trouble keeping track which does what, so add some Javadoc.

### Testing done

Had IntelliJ IDEA render the Javadoc and it looked fine.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
