### PR TITLE
Also add `DateTimeFormatter` `ofPattern` with `Locale`-parameter to the whitelist

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/generic-whitelist
@@ -488,6 +488,7 @@ staticField java.time.format.DateTimeFormatter ISO_WEEK_DATE
 staticField java.time.format.DateTimeFormatter ISO_ZONED_DATE_TIME
 staticField java.time.format.DateTimeFormatter RFC_1123_DATE_TIME
 staticMethod java.time.format.DateTimeFormatter ofPattern java.lang.String
+staticMethod java.time.format.DateTimeFormatter ofPattern java.lang.String java.util.Locale
 method java.time.format.DateTimeFormatter parse java.lang.CharSequence
 staticField java.time.temporal.ChronoUnit CENTURIES
 staticField java.time.temporal.ChronoUnit DAYS


### PR DESCRIPTION
Also add `DateTimeFormatter` `ofPattern` with Locale because with changes of Java 17 some locale now have a 4-digit month name, and we encountered problems with other tools. Some Background: [SO septembers-short-form-sep-no-longer-parses-in-java-17-in-en-gb-locale](https://stackoverflow.com/questions/69267710/septembers-short-form-sep-no-longer-parses-in-java-17-in-en-gb-locale)
Just providing another locale than our default resolves the issue.

### Testing done

None, just added this to the whitelist as it was added in our test instance.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
