### PR TITLE
Fix JenkinsWhitelistTest on 2.477 incremental

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,15 @@
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.387.3</jenkins.version>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.462</jenkins.baseline>
+    <!-- TODO Replace with the standard jenkins.baseline references after LTS requires Java 17  -->
+    <!-- <jenkins.version>${jenkins.baseline}.1</jenkins.version> -->
+    <!-- <jenkins.version>2.476</jenkins.version> -->
+    <jenkins.version>2.477-rc35350.7ff5a_a_a_0fdc3</jenkins.version>
+    <!-- TODO JENKINS-73339 until in parent POM -->
+    <jenkins-test-harness.version>2265.v3da_49c8134d6</jenkins-test-harness.version>
+    <maven.compiler.release>17</maven.compiler.release>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
   <licenses>
@@ -49,10 +57,16 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
-        <scope>import</scope>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>3358.vea_fa_1f41504d</version>
         <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- TODO JENKINS-73339 until in parent POM, work around https://github.com/jenkinsci/plugin-pom/issues/936 -->
+      <dependency>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>5.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -15,15 +15,7 @@
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.462</jenkins.baseline>
-    <!-- TODO Replace with the standard jenkins.baseline references after LTS requires Java 17  -->
-    <!-- <jenkins.version>${jenkins.baseline}.1</jenkins.version> -->
-    <!-- <jenkins.version>2.476</jenkins.version> -->
-    <jenkins.version>2.477-rc35350.7ff5a_a_a_0fdc3</jenkins.version>
-    <!-- TODO JENKINS-73339 until in parent POM -->
-    <jenkins-test-harness.version>2265.v3da_49c8134d6</jenkins-test-harness.version>
-    <maven.compiler.release>17</maven.compiler.release>
+    <jenkins.version>2.387.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
   <licenses>
@@ -57,16 +49,10 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3358.vea_fa_1f41504d</version>
-        <type>pom</type>
+        <artifactId>bom-2.387.x</artifactId>
+        <version>2543.vfb_1a_5fb_9496d</version>
         <scope>import</scope>
-      </dependency>
-      <!-- TODO JENKINS-73339 until in parent POM, work around https://github.com/jenkinsci/plugin-pom/issues/936 -->
-      <dependency>
-        <groupId>jakarta.servlet</groupId>
-        <artifactId>jakarta.servlet-api</artifactId>
-        <version>5.0.0</version>
+        <type>pom</type>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/whitelists/StaticWhitelistTest.java
@@ -156,6 +156,10 @@ public class StaticWhitelistTest {
             new MethodSignature(MatchResult.class, "hasMatch"),
             new MethodSignature(MatchResult.class, "namedGroups"),
             new MethodSignature(MatchResult.class, "start", String.class),
+            // TODO No longer exists after Jenkins includes https://github.com/jenkinsci/jenkins/pull/9674
+            // Remove once plugin depends on Jenkins 2.477 or newer
+            // Remove from jenkins-whitelist at the same time
+            new MethodSignature("hudson.model.Run", "getFullDisplayName"),
             // TODO Do not exist until Jenkins includes https://github.com/jenkinsci/jenkins/pull/9674
             new MethodSignature("jenkins.model.HistoricalBuild", "getFullDisplayName")
     ));


### PR DESCRIPTION
## Fix JenkinsWhitelistTest test on 2.477 incremental

The JenkinsWhitelistTest will fail because

  method hudson.model.Run getFullDisplayName does not exist (or is an override)

Uses the same technique as was used in:

* #576

Downstream of:

* https://github.com/jenkinsci/jenkins/pull/9674

### Testing done

Confirmed that the test fails when run with Jenkins incremental.  Failure is also visible in plugin BOM at https://github.com/jenkinsci/bom/pull/3574

* Shows the test failure on ci.jenkins.io as [build 1](https://ci.jenkins.io/job/Plugins/job/script-security-plugin/job/PR-578/1/testReport/).
* Shows the fix passes the test failure on ci.jenkins.io as [build 2](https://ci.jenkins.io/job/Plugins/job/script-security-plugin/job/PR-578/2).
* Shows the fix passes on older versions of Jenkins core in [build 3](https://ci.jenkins.io/job/Plugins/job/script-security-plugin/view/change-requests/job/PR-578/3/)

A release of the plugin with this test fix is needed before the plugin BOM can adopt Jenkins 2.477.  Jenkins 2.477 is scheduled for release Tuesday 17 Sep 2024 and is a possible candidate as the next LTS baseline (for 30 Oct 2024 release).

@jglick could you review, approve, and merge this fix?

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
