### PR TITLE
JENKINS-73941 - ForceSandbox - Align Script-Security plugin with preexisting behavior in Workflow-CPS plugin

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
@@ -62,6 +62,7 @@ import org.codehaus.groovy.control.SourceUnit;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ClasspathEntry;
+import org.jenkinsci.plugins.scriptsecurity.scripts.Messages;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.scriptsecurity.scripts.UnapprovedClasspathException;
 import org.jenkinsci.plugins.scriptsecurity.scripts.UnapprovedUsageException;
@@ -92,13 +93,18 @@ public final class SecureGroovyScript extends AbstractDescribableImpl<SecureGroo
 
     static final Logger LOGGER = Logger.getLogger(SecureGroovyScript.class.getName());
 
-    @DataBoundConstructor public SecureGroovyScript(@NonNull String script, boolean sandbox, @CheckForNull List<ClasspathEntry> classpath) {
+    @DataBoundConstructor public SecureGroovyScript(@NonNull String script, boolean sandbox,
+                                                    @CheckForNull List<ClasspathEntry> classpath)
+            throws Descriptor.FormException {
+        if (!sandbox && ScriptApproval.get().isForceSandboxForCurrentUser()) {
+            throw new Descriptor.FormException(Messages.ScriptApproval_SandboxCantBeDisabled(), "sandbox");
+        }
         this.script = script;
         this.sandbox = sandbox;
         this.classpath = classpath;
     }
 
-    @Deprecated public SecureGroovyScript(@NonNull String script, boolean sandbox) {
+    @Deprecated public SecureGroovyScript(@NonNull String script, boolean sandbox) throws Descriptor.FormException  {
         this(script, sandbox, null);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -829,7 +829,7 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
                                                     Messages.ScriptApproval_PipelineMessage());
         } else {
             String forceSandboxMessage = isForceSandbox() ?
-                                         Messages.ScriptApproval_ForceSandBoxMessage() + System.lineSeparator() :
+                                         Messages.ScriptApproval_AdminUserAlert() :
                                          "";
 
             if ((ALLOW_ADMIN_APPROVAL_ENABLED && (willBeApproved || ADMIN_AUTO_APPROVAL_ENABLED)) || !Jenkins.get().isUseSecurity()) {

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -818,7 +818,9 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
         }
         final ConversionCheckResult result = checkAndConvertApprovedScript(script, language);
         if (result.approved) {
-            return FormValidation.okWithMarkup("The script is already approved");
+            return FormValidation.okWithMarkup(isForceSandboxForCurrentUser() ?
+                                               Messages.ScriptApproval_ForceSandBoxMessage() :
+                                               "The script is already approved");
         }
 
         if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
@@ -826,11 +828,16 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
                                                     Messages.ScriptApproval_ForceSandBoxMessage() :
                                                     Messages.ScriptApproval_PipelineMessage());
         } else {
+            String forceSandboxMessage = isForceSandbox() ?
+                                         Messages.ScriptApproval_ForceSandBoxMessage() + System.lineSeparator() :
+                                         "";
+
             if ((ALLOW_ADMIN_APPROVAL_ENABLED && (willBeApproved || ADMIN_AUTO_APPROVAL_ENABLED)) || !Jenkins.get().isUseSecurity()) {
-                return FormValidation.okWithMarkup("The script has not yet been approved, but it will be approved on save.");
+                return FormValidation.okWithMarkup(forceSandboxMessage + "The script has not yet been approved, "
+                                                   + "but it will be approved on save.");
             }
             String approveScript = "<a class='jenkins-button script-approval-approve-link' data-base-url='" + Jenkins.get().getRootUrl() + ScriptApproval.get().getUrlName() + "' data-hash='" + result.newHash + "'>Approve script</a>";
-            return FormValidation.okWithMarkup("The script is not approved and will not be approved on save. " +
+            return FormValidation.okWithMarkup(forceSandboxMessage + "The script is not approved and will not be approved on save. " +
                     "Either modify the script to match an already approved script, approve it explicitly on the " +
                     "<a target='blank' href='"+ Jenkins.get().getRootUrl() + ScriptApproval.get().getUrlName() + "'>Script Approval Configuration</a> page after save, or approve this version of the script. " +
                     approveScript);

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/Messages.properties
@@ -11,3 +11,4 @@ ScriptApproval.PipelineMessage=A Jenkins administrator will need to approve this
 ScriptApproval.ForceSandBoxMessage=Running scripts out of the sandbox is not allowed in the system
 UnapprovedUsage.NonApproved=script not yet approved for use
 UnapprovedUsage.ForceSandBox=Running scripts out of the sandbox is not allowed in the system
+ScriptApproval.SandboxCantBeDisabled=Sandbox cannot be disabled. This Jenkins instance has been configured to not allow regular users to disable the sandbox in the system

--- a/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/scriptsecurity/scripts/Messages.properties
@@ -12,3 +12,4 @@ ScriptApproval.ForceSandBoxMessage=Running scripts out of the sandbox is not all
 UnapprovedUsage.NonApproved=script not yet approved for use
 UnapprovedUsage.ForceSandBox=Running scripts out of the sandbox is not allowed in the system
 ScriptApproval.SandboxCantBeDisabled=Sandbox cannot be disabled. This Jenkins instance has been configured to not allow regular users to disable the sandbox in the system
+ScriptApproval.AdminUserAlert=<b>Sandbox is enabled globally in the system.</b><br />

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
@@ -326,22 +326,22 @@ public class ScriptApprovalTest extends AbstractApprovalTest<ScriptApprovalTest.
             {
                 FormValidation result = ScriptApproval.get().checking("test", GroovyLanguage.get(), false);
                 assertEquals(FormValidation.Kind.OK, result.kind);
-                assertTrue(result.getMessage().contains(Messages.ScriptApproval_ForceSandBoxMessage()));
+                assertTrue(result.getMessage().contains(Messages.ScriptApproval_AdminUserAlert()));
 
                 result = ScriptApproval.get().checking("test", GroovyLanguage.get(), true);
                 assertEquals(FormValidation.Kind.OK, result.kind);
-                assertTrue(result.getMessage().contains(Messages.ScriptApproval_ForceSandBoxMessage()));
+                assertTrue(result.getMessage().contains(Messages.ScriptApproval_AdminUserAlert()));
             }
 
             ScriptApproval.get().setForceSandbox(false);
             {
                 FormValidation result = ScriptApproval.get().checking("test", GroovyLanguage.get(), false);
                 assertEquals(FormValidation.Kind.OK, result.kind);
-                assertFalse(result.getMessage().contains(Messages.ScriptApproval_ForceSandBoxMessage()));
+                assertFalse(result.getMessage().contains(Messages.ScriptApproval_AdminUserAlert()));
 
                 result = ScriptApproval.get().checking("test", GroovyLanguage.get(), true);
                 assertEquals(FormValidation.Kind.OK, result.kind);
-                assertFalse(result.getMessage().contains(Messages.ScriptApproval_ForceSandBoxMessage()));
+                assertFalse(result.getMessage().contains(Messages.ScriptApproval_AdminUserAlert()));
             }
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalTest.java
@@ -301,7 +301,8 @@ public class ScriptApprovalTest extends AbstractApprovalTest<ScriptApprovalTest.
     public void forceSandboxFormValidation() throws Exception {
         r.jenkins.setSecurityRealm(r.createDummySecurityRealm());
         r.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().
-            grant(Jenkins.READ, Item.READ).everywhere().to("dev"));
+            grant(Jenkins.READ, Item.READ).everywhere().to("dev").
+            grant(Jenkins.ADMINISTER).everywhere().to("admin"));
 
         try (ACLContext ctx = ACL.as(User.getById("devel", true))) {
             ScriptApproval.get().setForceSandbox(true);
@@ -316,6 +317,31 @@ public class ScriptApprovalTest extends AbstractApprovalTest<ScriptApprovalTest.
                 FormValidation result = ScriptApproval.get().checking("test", GroovyLanguage.get(), false);
                 assertEquals(FormValidation.Kind.WARNING, result.kind);
                 assertEquals(Messages.ScriptApproval_PipelineMessage(), result.getMessage());
+            }
+        }
+
+        try (ACLContext ctx = ACL.as(User.getById("admin", true))) {
+
+            ScriptApproval.get().setForceSandbox(true);
+            {
+                FormValidation result = ScriptApproval.get().checking("test", GroovyLanguage.get(), false);
+                assertEquals(FormValidation.Kind.OK, result.kind);
+                assertTrue(result.getMessage().contains(Messages.ScriptApproval_ForceSandBoxMessage()));
+
+                result = ScriptApproval.get().checking("test", GroovyLanguage.get(), true);
+                assertEquals(FormValidation.Kind.OK, result.kind);
+                assertTrue(result.getMessage().contains(Messages.ScriptApproval_ForceSandBoxMessage()));
+            }
+
+            ScriptApproval.get().setForceSandbox(false);
+            {
+                FormValidation result = ScriptApproval.get().checking("test", GroovyLanguage.get(), false);
+                assertEquals(FormValidation.Kind.OK, result.kind);
+                assertFalse(result.getMessage().contains(Messages.ScriptApproval_ForceSandBoxMessage()));
+
+                result = ScriptApproval.get().checking("test", GroovyLanguage.get(), true);
+                assertEquals(FormValidation.Kind.OK, result.kind);
+                assertFalse(result.getMessage().contains(Messages.ScriptApproval_ForceSandBoxMessage()));
             }
         }
     }


### PR DESCRIPTION
[JENKINS-73941](https://issues.jenkins.io/browse/JENKINS-73941) - Option to hide "Use Groovy Sandbox" for users without Administer permission globally in the system

Related to 
- https://github.com/jenkinsci/script-security-plugin/pull/584
- https://github.com/jenkinsci/workflow-cps-plugin/pull/948

In https://github.com/jenkinsci/script-security-plugin/pull/584 we implemented the new forceSandbox logic in the Script Security Plugin instead of the Workflow-CPS Plugin.

The specific SandBox implementations are managed in the specific plugins, and in WorkflowCPS there are some functionalities not properly migrated in the previous PR to this repo

When the ForceSandbox option is enabled in the system:

- In WorkFlow-CPS, when a preexistent Pipeline has the sandBox disabled, a nonAdmin user can't edit it (the plugin is throwing an exception)
- In the Script-Security-Plugin, we have a Sandbox template implemented in [org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript](https://github.com/jenkinsci/script-security-plugin/blob/master/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java), but this behavior was not migrated, so when a preexistent Pipeline has the sandBox disabled, a nonAdmin user can edit it.

We have aligned both behaviors.

In addition, for admin users, when running the FormValidation, we haven't changed the behavior (the ForceSandbox does not apply to admin), but we have added in the message some information about Sandbox not allowed in the system.

### Testing done

New test cases were included to cover the described changes.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
