### PR TITLE
JENKINS-73941 - ForceSandbox - Unify logic in Script-Security for reducing techDebt

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
@@ -28,6 +28,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import groovy.lang.Binding;
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyShell;
+import groovy.lang.Script;
+
 import hudson.Extension;
 import hudson.PluginManager;
 import hudson.model.AbstractDescribableImpl;
@@ -96,9 +98,8 @@ public final class SecureGroovyScript extends AbstractDescribableImpl<SecureGroo
     @DataBoundConstructor public SecureGroovyScript(@NonNull String script, boolean sandbox,
                                                     @CheckForNull List<ClasspathEntry> classpath)
             throws Descriptor.FormException {
-        if (!sandbox && ScriptApproval.get().isForceSandboxForCurrentUser()) {
-            throw new Descriptor.FormException(Messages.ScriptApproval_SandboxCantBeDisabled(), "sandbox");
-        }
+        ScriptApproval.validateSandbox(sandbox);
+
         this.script = script;
         this.sandbox = sandbox;
         this.classpath = classpath;
@@ -473,8 +474,7 @@ public final class SecureGroovyScript extends AbstractDescribableImpl<SecureGroo
         public boolean shouldHideSandbox(@CheckForNull SecureGroovyScript instance) {
             // sandbox checkbox is shown to admins even if the global configuration says otherwise
             // it's also shown when sandbox == false, so regular users can enable it
-            return ScriptApproval.get().isForceSandboxForCurrentUser()
-                   && (instance == null || instance.sandbox);
+            return ScriptApproval.shouldHideSandbox(instance,SecureGroovyScript::isSandbox);
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
@@ -28,8 +28,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import groovy.lang.Binding;
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyShell;
-import groovy.lang.Script;
-
 import hudson.Extension;
 import hudson.PluginManager;
 import hudson.model.AbstractDescribableImpl;

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -26,11 +26,14 @@ package org.jenkinsci.plugins.scriptsecurity.scripts;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.BallColor;
+import hudson.model.Descriptor;
 import hudson.model.PageDecorator;
 import hudson.security.ACLContext;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.util.SystemProperties;
+
+import gnu.crypto.hash.IMessageDigest;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
@@ -68,6 +71,7 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -1335,4 +1339,15 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
     @Restricted(NoExternalUse.class)
     @Extension
     public static class FormValidationPageDecorator extends PageDecorator {}
+
+    public static <T> boolean shouldHideSandbox(@CheckForNull T instance, Predicate<T> isSandbox){
+        return get().isForceSandboxForCurrentUser()
+               && (instance == null || isSandbox.test(instance));
+    }
+
+    public static void validateSandbox(boolean sandbox) throws Descriptor.FormException{
+        if (!sandbox && get().isForceSandboxForCurrentUser()) {
+            throw new Descriptor.FormException(Messages.ScriptApproval_SandboxCantBeDisabled(), "sandbox");
+        }
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -1008,7 +1008,6 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
 
     /**
      * Flag indicating whether the current system is blocking non sandbox operations for non Admin users.
-      * @return
      */
     public boolean isForceSandbox() {
         return forceSandbox;
@@ -1017,7 +1016,6 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
     /**
      * Logic to indicate if the flag {@link #isForceSandbox} applies for the current user. <br />
      * It does not apply for admin users.
-     * @return
      */
     public boolean isForceSandboxForCurrentUser() {
         return forceSandbox && !Jenkins.get().hasPermission(Jenkins.ADMINISTER);
@@ -1349,11 +1347,7 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
      * All sandbox checkboxes in the system should confirm their visibility based on this flag.<br />
      * It depends on the current sandbox value in the affected instance and
      * {@link org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval#isForceSandboxForCurrentUser}
-     * @param instance
-     * @param isSandbox
-     * method in the instance class confirming the sandbox current value for the instance.
-     * @return
-     * @param <T>
+     * @param isSandbox method handle in the instance class confirming the sandbox current value for the instance.
      */
     public static <T> boolean shouldHideSandbox(@CheckForNull T instance, Predicate<T> isSandbox){
         return get().isForceSandboxForCurrentUser()
@@ -1363,7 +1357,7 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
     /**
      * All describable containing the Sandbox flag should invoke this method before saving.<br />
      * It will confirm if the current user can persist the information in case the sandbox flag is disabled.
-     * It depends on {@link org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval#isForceSandboxForCurrentUser}
+     * It depends on {@link #isForceSandboxForCurrentUser}
      * In case the current user can't save it will raise a new {@link Descriptor.FormException}
      * @param sandbox
      * @throws Descriptor.FormException

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -32,8 +32,6 @@ import hudson.security.ACLContext;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.GlobalConfigurationCategory;
 import jenkins.util.SystemProperties;
-
-import gnu.crypto.hash.IMessageDigest;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -1359,8 +1359,6 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
      * It will confirm if the current user can persist the information in case the sandbox flag is disabled.
      * It depends on {@link #isForceSandboxForCurrentUser}
      * In case the current user can't save it will raise a new {@link Descriptor.FormException}
-     * @param sandbox
-     * @throws Descriptor.FormException
      */
     public static void validateSandbox(boolean sandbox) throws Descriptor.FormException{
         if (!sandbox && get().isForceSandboxForCurrentUser()) {

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -1346,7 +1346,7 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
     /**
      * All sandbox checkboxes in the system should confirm their visibility based on this flag.<br />
      * It depends on the current sandbox value in the affected instance and
-     * {@link org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval#isForceSandboxForCurrentUser}
+     * {@link #isForceSandboxForCurrentUser}
      * @param isSandbox method handle in the instance class confirming the sandbox current value for the instance.
      */
     public static <T> boolean shouldHideSandbox(@CheckForNull T instance, Predicate<T> isSandbox){

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -1006,12 +1006,19 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
         save();
     }
 
-
+    /**
+     * Flag indicating whether the current system is blocking non sandbox operations for non Admin users.
+      * @return
+     */
     public boolean isForceSandbox() {
         return forceSandbox;
     }
 
-    //ForceSandbox restrictions does not apply to ADMINISTER users.
+    /**
+     * Logic to indicate if the flag {@link #isForceSandbox} applies for the current user. <br />
+     * It does not apply for admin users.
+     * @return
+     */
     public boolean isForceSandboxForCurrentUser() {
         return forceSandbox && !Jenkins.get().hasPermission(Jenkins.ADMINISTER);
     }
@@ -1338,11 +1345,29 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
     @Extension
     public static class FormValidationPageDecorator extends PageDecorator {}
 
+    /**
+     * All sandbox checkboxes in the system should confirm their visibility based on this flag.<br />
+     * It depends on the current sandbox value in the affected instance and
+     * {@link org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval#isForceSandboxForCurrentUser}
+     * @param instance
+     * @param isSandbox
+     * method in the instance class confirming the sandbox current value for the instance.
+     * @return
+     * @param <T>
+     */
     public static <T> boolean shouldHideSandbox(@CheckForNull T instance, Predicate<T> isSandbox){
         return get().isForceSandboxForCurrentUser()
                && (instance == null || isSandbox.test(instance));
     }
 
+    /**
+     * All describable containing the Sandbox flag should invoke this method before saving.<br />
+     * It will confirm if the current user can persist the information in case the sandbox flag is disabled.
+     * It depends on {@link org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval#isForceSandboxForCurrentUser}
+     * In case the current user can't save it will raise a new {@link Descriptor.FormException}
+     * @param sandbox
+     * @throws Descriptor.FormException
+     */
     public static void validateSandbox(boolean sandbox) throws Descriptor.FormException{
         if (!sandbox && get().isForceSandboxForCurrentUser()) {
             throw new Descriptor.FormException(Messages.ScriptApproval_SandboxCantBeDisabled(), "sandbox");


### PR DESCRIPTION
[JENKINS-73941 -  - Option to hide "Use Groovy Sandbox" for users without Administer permission globally in the system](https://issues.jenkins.io/browse/JENKINS-73941)

Complements:
https://github.com/jenkinsci/script-security-plugin/pull/584
https://github.com/jenkinsci/script-security-plugin/pull/585


After releasing https://github.com/jenkinsci/workflow-cps-plugin/pull/948 we have realized that some logic can be unified between Script-Security and Workflow-CPS plugin.

To do so, we have created the new static methods:
* org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval#shouldHideSandbox
* org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval#validateSandbox

This PR does not include any new functionality, but decrease the techDebt maintaining both, Script-Security and Workflow-CPS Plugin

### Testing done
Created new test cases for the created methods.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
