### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ When unset, you need to call` ScriptApproval.configuring` in the `@DataBoundCons
 Use `ApprovalContext.withCurrentUser`, and also `withItemAsKey` where applicable (when 
 there is just one script per job); otherwise at least withItem where applicable, and/or 
 `withKey` when you can uniquely identify this usage from the context 
-(`StaplerRequest.findAncestorObject` is helpful here). This lets the system know a 
+(`StaplerRequest2.findAncestorObject` is helpful here). This lets the system know a 
 (possibly) new script has been configured by a particular person. You will also need a 
 `readResolve` that calls configuring to notify the system when a configurable with script 
 has been loaded from disk (and thus the configurer is unknown). Call 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath/>
   </parent>
 
@@ -16,8 +16,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.387</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
   <licenses>
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <version>3893.v213a_42768d35</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
@@ -73,7 +73,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 /**
@@ -155,7 +155,7 @@ public final class SecureGroovyScript extends AbstractDescribableImpl<SecureGroo
     }
 
     private static @CheckForNull Item currentItem() {
-        StaplerRequest req = Stapler.getCurrentRequest();
+        StaplerRequest2 req = Stapler.getCurrentRequest2();
         return req != null ? req.findAncestorObject(Item.class) : null;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalNote.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApprovalNote.java
@@ -39,7 +39,7 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Offers a link to {@link ScriptApproval}.
@@ -69,7 +69,7 @@ public class ScriptApprovalNote extends ConsoleNote<Object> {
     public ConsoleAnnotator<Object> annotate(Object context, MarkupText text, int charPos) {
         if (Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
             String url = ScriptApproval.get().getUrlName();
-            StaplerRequest req = Stapler.getCurrentRequest();
+            StaplerRequest2 req = Stapler.getCurrentRequest2();
             if (req != null) {
                 // if we are serving HTTP request, we want to use app relative URL
                 url = req.getContextPath() + "/" + url;


### PR DESCRIPTION
Migrate from deprecated EE 8 functionality to non-deprecated EE 9 equivalents.

### Testing done

`mvn clean verify`