### PR TITLE
Remove usages of Commons Lang 2

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/GroovyCallSiteSelector.java
@@ -39,7 +39,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.commons.lang.ClassUtils;
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
 /**
@@ -74,7 +73,7 @@ class GroovyCallSiteSelector {
             if (
                     parameterTypes[i].isPrimitive()
                     && parameters[i] != null
-                    && isInstancePrimitive(ClassUtils.primitiveToWrapper(parameterTypes[i]), parameters[i])
+                    && isInstancePrimitive(Primitives.wrap(parameterTypes[i]), parameters[i])
             ) {
                 // Groovy passes primitive values as objects (for example, passes 0 as Integer(0))
                 // The prior test fails as int.class.isInstance(new Integer(0)) returns false.
@@ -99,7 +98,7 @@ class GroovyCallSiteSelector {
         Class<?> componentType = parameterTypes[fixedLen].getComponentType();
         assert componentType != null;
         if (componentType.isPrimitive()) {
-            componentType = ClassUtils.primitiveToWrapper(componentType);
+            componentType = Primitives.wrap(componentType);
         }
         int arrayLength = parameters.length - fixedLen;
 

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScript.java
@@ -48,13 +48,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.SourceUnit;
@@ -145,7 +145,7 @@ public final class SecureGroovyScript extends AbstractDescribableImpl<SecureGroo
     public SecureGroovyScript configuring(ApprovalContext context) {
         calledConfiguring = true;
         if (!sandbox) {
-            ScriptApproval.get().configuring(script, GroovyLanguage.get(), context, !StringUtils.equals(this.oldScript, this.script));
+            ScriptApproval.get().configuring(script, GroovyLanguage.get(), context, !Objects.equals(this.oldScript, this.script));
         }
         for (ClasspathEntry entry : getClasspath()) {
             ScriptApproval.get().configuring(entry, context);
@@ -462,7 +462,7 @@ public final class SecureGroovyScript extends AbstractDescribableImpl<SecureGroo
             if (validationResult.kind != FormValidation.Kind.OK) {
                 return validationResult;
             }
-            return sandbox ? FormValidation.ok() : ScriptApproval.get().checking(value, GroovyLanguage.get(), !StringUtils.equals(oldScript, value));
+            return sandbox ? FormValidation.ok() : ScriptApproval.get().checking(value, GroovyLanguage.get(), !Objects.equals(oldScript, value));
         }
 
         @Restricted(NoExternalUse.class) // stapler

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ClasspathEntry.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.io.Serializable;
 
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -208,7 +207,7 @@ public final class ClasspathEntry extends AbstractDescribableImpl<ClasspathEntry
             if(!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return FormValidation.ok();
             }
-            if (StringUtils.isBlank(value)) {
+            if (value == null || value.isBlank()) {
                 return FormValidation.warning("Enter a file path or URL."); // TODO I18N
             }
             try {

--- a/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
+++ b/src/main/java/org/jenkinsci/plugins/scriptsecurity/scripts/ScriptApproval.java
@@ -34,7 +34,6 @@ import jenkins.model.GlobalConfigurationCategory;
 import jenkins.util.SystemProperties;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.AclAwareWhitelist;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
@@ -65,6 +64,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Stack;
 import java.util.TreeSet;
@@ -735,7 +735,7 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
             PendingClasspathEntry pcp = new PendingClasspathEntry(result.newHash, url, context);
             if (!Jenkins.get().isUseSecurity() ||
                     ((Jenkins.getAuthentication2() != ACL.SYSTEM2 && Jenkins.get().hasPermission(Jenkins.ADMINISTER))
-                            && (ADMIN_AUTO_APPROVAL_ENABLED || entry.isShouldBeApproved() || !StringUtils.equals(entry.getOldPath(), entry.getPath())))) {
+                            && (ADMIN_AUTO_APPROVAL_ENABLED || entry.isShouldBeApproved() || !Objects.equals(entry.getOldPath(), entry.getPath())))) {
                 LOG.log(Level.FINE, "Classpath entry {0} ({1}) is approved as configured with ADMINISTER permission.", new Object[] {url, result.newHash});
                 ApprovedClasspathEntry acp = new ApprovedClasspathEntry(result.newHash, url);
                 pendingClasspathEntries.remove(pcp);
@@ -815,7 +815,7 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
      *          if script is approved
      */
     public synchronized FormValidation checking(@NonNull String script, @NonNull Language language, boolean willBeApproved) {
-        if (StringUtils.isEmpty(script)) {
+        if (script == null || script.isEmpty()) {
             return FormValidation.ok();
         }
         final ConversionCheckResult result = checkAndConvertApprovedScript(script, language);
@@ -976,7 +976,7 @@ public final class ScriptApproval extends GlobalConfiguration implements RootAct
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         approvedScriptHashes.clear();
         for (String scriptHash : scriptHashes) {
-            if (StringUtils.isNotEmpty(scriptHash)) {
+            if (scriptHash != null && !scriptHash.isEmpty()) {
                 if (DEFAULT_HASHER.pattern().matcher(scriptHash).matches()) {
                     approvedScriptHashes.add(scriptHash);
                 } else {

--- a/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScriptTest.java
+++ b/src/test/java/org/jenkinsci/plugins/scriptsecurity/sandbox/groovy/SecureGroovyScriptTest.java
@@ -57,9 +57,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.taskdefs.Expand;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
@@ -341,7 +342,7 @@ public class SecureGroovyScriptTest {
     }
 
     private List<File> getAllJarFiles() throws URISyntaxException {
-        String testClassPath = String.format(StringUtils.join(getClass().getName().split("\\."), "/"));
+        String testClassPath = Stream.of(getClass().getName().split("\\.")).collect(Collectors.joining("/"));
         File testClassDir = new File(ClassLoader.getSystemResource(testClassPath).toURI()).getAbsoluteFile();
         
         DirectoryScanner ds = new DirectoryScanner();
@@ -378,7 +379,7 @@ public class SecureGroovyScriptTest {
     }
 
     private List<File> getAllUpdatedJarFiles() throws URISyntaxException {
-        String testClassPath = StringUtils.join(getClass().getName().split("\\."), "/");
+        String testClassPath = Stream.of(getClass().getName().split("\\.")).collect(Collectors.joining("/"));
         File testClassDir = new File(ClassLoader.getSystemResource(testClassPath).toURI()).getAbsoluteFile();
         
         File updatedDir = new File(testClassDir, "updated");


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to native Java Platform or Guava methods.